### PR TITLE
Implement symbolic vocabulary and rule parser

### DIFF
--- a/arc_solver/src/symbolic/__init__.py
+++ b/arc_solver/src/symbolic/__init__.py
@@ -1,0 +1,22 @@
+"""Symbolic reasoning primitives and DSL parsing."""
+
+from .vocabulary import (
+    Symbol,
+    SymbolType,
+    SymbolicRule,
+    Transformation,
+    TransformationNature,
+    TransformationType,
+)
+from .rule_language import parse_rule, rule_to_dsl
+
+__all__ = [
+    "Symbol",
+    "SymbolType",
+    "SymbolicRule",
+    "Transformation",
+    "TransformationNature",
+    "TransformationType",
+    "parse_rule",
+    "rule_to_dsl",
+]

--- a/arc_solver/src/symbolic/rule_language.py
+++ b/arc_solver/src/symbolic/rule_language.py
@@ -1,0 +1,60 @@
+"""Parsing utilities for the symbolic rule DSL."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .vocabulary import (
+    Symbol,
+    SymbolType,
+    SymbolicRule,
+    Transformation,
+    TransformationNature,
+    TransformationType,
+)
+
+
+def _parse_symbol(token: str) -> Symbol:
+    key, value = token.split("=", 1)
+    key = key.strip().upper()
+    value = value.strip()
+    try:
+        stype = SymbolType[key]
+    except KeyError as exc:
+        raise ValueError(f"Unknown symbol type: {key}") from exc
+    return Symbol(stype, value)
+
+
+def _parse_symbol_list(text: str) -> List[Symbol]:
+    if not text.startswith("[") or not text.endswith("]"):
+        raise ValueError(f"Invalid symbol list: {text}")
+    content = text[1:-1].strip()
+    if not content:
+        return []
+    parts = [p.strip() for p in content.split(",")]
+    return [_parse_symbol(part) for part in parts]
+
+
+def parse_rule(text: str) -> SymbolicRule:
+    text = text.strip()
+    if " " not in text:
+        raise ValueError("Invalid rule format")
+    op, remainder = text.split(" ", 1)
+    try:
+        ttype = TransformationType[op.upper()]
+    except KeyError as exc:
+        raise ValueError(f"Unknown transformation type: {op}") from exc
+    if "->" not in remainder:
+        raise ValueError("Rule must contain '->'")
+    left_str, right_str = [part.strip() for part in remainder.split("->", 1)]
+    left_syms = _parse_symbol_list(left_str)
+    right_syms = _parse_symbol_list(right_str)
+    transformation = Transformation(ttype)
+    return SymbolicRule(transformation=transformation, source=left_syms, target=right_syms)
+
+
+def rule_to_dsl(rule: SymbolicRule) -> str:
+    return str(rule)
+
+
+__all__ = ["parse_rule", "rule_to_dsl"]

--- a/arc_solver/src/symbolic/vocabulary.py
+++ b/arc_solver/src/symbolic/vocabulary.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+"""Symbolic vocabulary definitions for the ARC cognitive engine."""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List
+
+
+class SymbolType(Enum):
+    """Types of symbolic attributes."""
+
+    COLOR = "COLOR"
+    SHAPE = "SHAPE"
+    REGION = "REGION"
+    ZONE = "ZONE"
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.value
+
+
+class TransformationType(Enum):
+    """Supported symbolic transformation primitives."""
+
+    REPLACE = "REPLACE"
+    TRANSLATE = "TRANSLATE"
+    MERGE = "MERGE"
+    FILTER = "FILTER"
+    ROTATE = "ROTATE"
+    REFLECT = "REFLECT"
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.value
+
+
+class TransformationNature(Enum):
+    """Nature or category of a transformation."""
+
+    SPATIAL = "SPATIAL"
+    LOGICAL = "LOGICAL"
+    SYMMETRIC = "SYMMETRIC"
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.value
+
+
+@dataclass(frozen=True)
+class Symbol:
+    """Represents an abstract symbolic attribute."""
+
+    type: SymbolType
+    value: str
+
+    def __str__(self) -> str:
+        return f"{self.type.value}={self.value}"
+
+    def __repr__(self) -> str:  # pragma: no cover - simple
+        return f"Symbol(type={self.type}, value={self.value!r})"
+
+
+@dataclass(frozen=True)
+class Transformation:
+    """A symbolic transformation with optional parameters."""
+
+    ttype: TransformationType
+    params: Dict[str, str] = field(default_factory=dict)
+
+    def __str__(self) -> str:
+        if self.params:
+            param_str = ", ".join(f"{k}={v}" for k, v in self.params.items())
+            return f"{self.ttype.value}({param_str})"
+        return self.ttype.value
+
+    def __repr__(self) -> str:  # pragma: no cover - simple
+        return f"Transformation(ttype={self.ttype}, params={self.params})"
+
+
+@dataclass(frozen=True)
+class SymbolicRule:
+    """Structured rule describing a symbolic transformation."""
+
+    transformation: Transformation
+    source: List[Symbol]
+    target: List[Symbol]
+    nature: TransformationNature | None = None
+
+    def __str__(self) -> str:
+        left = ", ".join(str(s) for s in self.source)
+        right = ", ".join(str(s) for s in self.target)
+        nature_str = f" [{self.nature.value}]" if self.nature else ""
+        return f"{self.transformation.ttype.value} [{left}] -> [{right}]{nature_str}"
+
+    def __repr__(self) -> str:  # pragma: no cover - simple
+        return (
+            "SymbolicRule("
+            f"transformation={self.transformation!r}, "
+            f"source={self.source!r}, "
+            f"target={self.target!r}, nature={self.nature!r})"
+        )
+
+
+__all__ = [
+    "SymbolType",
+    "TransformationType",
+    "TransformationNature",
+    "Symbol",
+    "Transformation",
+    "SymbolicRule",
+]

--- a/arc_solver/tests/test_symbolic.py
+++ b/arc_solver/tests/test_symbolic.py
@@ -1,0 +1,8 @@
+from arc_solver.src.symbolic import parse_rule, SymbolType, TransformationType
+
+
+def test_parse_rule_basic():
+    rule = parse_rule("REPLACE [ZONE=TopLeft, COLOR=Red] -> [COLOR=Blue]")
+    assert rule.transformation.ttype is TransformationType.REPLACE
+    assert any(sym.type is SymbolType.ZONE and sym.value == "TopLeft" for sym in rule.source)
+    assert any(sym.type is SymbolType.COLOR and sym.value == "Blue" for sym in rule.target)


### PR DESCRIPTION
## Summary
- add symbolic vocabulary definitions with enums and dataclasses
- implement parsing and formatting of a simple symbolic DSL
- expose new functions in `arc_solver.src.symbolic`
- test parsing of example rule

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff858653c8322b388e244aef183ec