### PR TITLE
Add symbolic abstraction engine

### DIFF
--- a/arc_solver/src/abstractions/__init__.py
+++ b/arc_solver/src/abstractions/__init__.py
@@ -1,0 +1,21 @@
+"""Symbolic abstraction utilities."""
+
+from .abstractor import (
+    extract_color_change_rules,
+    extract_shape_based_rules,
+    extract_zonewise_rules,
+    abstract,
+)
+from .rule_generator import generalize_rules, score_rules
+from .transformation_library import ReplaceColor, TRANSFORMATIONS
+
+__all__ = [
+    "extract_color_change_rules",
+    "extract_shape_based_rules",
+    "extract_zonewise_rules",
+    "abstract",
+    "generalize_rules",
+    "score_rules",
+    "ReplaceColor",
+    "TRANSFORMATIONS",
+]

--- a/arc_solver/src/abstractions/abstractor.py
+++ b/arc_solver/src/abstractions/abstractor.py
@@ -1,6 +1,165 @@
-"""Abstraction utilities."""
+"""Symbolic rule extraction utilities for ARC problems."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic.vocabulary import (
+    Symbol,
+    SymbolType,
+    SymbolicRule,
+    Transformation,
+    TransformationNature,
+    TransformationType,
+)
 
 
-def abstract(objects):
-    """Return symbolic abstractions of objects."""
-    return []
+# ---------------------------------------------------------------------------
+# Core extraction functions
+# ---------------------------------------------------------------------------
+
+def extract_color_change_rules(input_grid: Grid, output_grid: Grid) -> List[SymbolicRule]:
+    """Return rules describing consistent color replacements.
+
+    A simple cell-wise comparison is used to detect cases where all occurrences
+    of one color become another color.
+    """
+    if input_grid.shape() != output_grid.shape():
+        return []
+
+    mappings: Dict[int, set[int]] = {}
+    h, w = input_grid.shape()
+    for r in range(h):
+        for c in range(w):
+            src = input_grid.get(r, c)
+            tgt = output_grid.get(r, c)
+            if src != tgt:
+                mappings.setdefault(src, set()).add(tgt)
+
+    rules: List[SymbolicRule] = []
+    for src_color, tgts in mappings.items():
+        if len(tgts) == 1:
+            tgt_color = next(iter(tgts))
+            rule = SymbolicRule(
+                transformation=Transformation(TransformationType.REPLACE),
+                source=[Symbol(SymbolType.COLOR, str(src_color))],
+                target=[Symbol(SymbolType.COLOR, str(tgt_color))],
+                nature=TransformationNature.LOGICAL,
+            )
+            rules.append(rule)
+    return rules
+
+
+def extract_zonewise_rules(
+    input_grid: Grid,
+    output_grid: Grid,
+    zone_overlay: Optional[List[List[Symbol]]] = None,
+) -> List[SymbolicRule]:
+    """Return color replacement rules conditioned on zone overlays."""
+    if zone_overlay is None or input_grid.shape() != output_grid.shape():
+        return []
+
+    h, w = input_grid.shape()
+    zone_mappings: Dict[str, Dict[int, set[int]]] = {}
+    for r in range(h):
+        for c in range(w):
+            zone = zone_overlay[r][c].value
+            src = input_grid.get(r, c)
+            tgt = output_grid.get(r, c)
+            if src != tgt:
+                zone_map = zone_mappings.setdefault(zone, {})
+                zone_map.setdefault(src, set()).add(tgt)
+
+    rules: List[SymbolicRule] = []
+    for zone, mapping in zone_mappings.items():
+        for src_color, tgts in mapping.items():
+            if len(tgts) == 1:
+                tgt_color = next(iter(tgts))
+                rules.append(
+                    SymbolicRule(
+                        transformation=Transformation(TransformationType.REPLACE),
+                        source=[
+                            Symbol(SymbolType.ZONE, zone),
+                            Symbol(SymbolType.COLOR, str(src_color)),
+                        ],
+                        target=[Symbol(SymbolType.COLOR, str(tgt_color))],
+                        nature=TransformationNature.LOGICAL,
+                    )
+                )
+    return rules
+
+
+def _find_translation(input_grid: Grid, output_grid: Grid) -> Optional[Tuple[int, int]]:
+    """Return translation offset if output is a translated version of input."""
+    if input_grid.shape() != output_grid.shape():
+        return None
+
+    h, w = input_grid.shape()
+    points_in: List[Tuple[int, int, int]] = []
+    points_out: List[Tuple[int, int, int]] = []
+    for r in range(h):
+        for c in range(w):
+            val_in = input_grid.get(r, c)
+            val_out = output_grid.get(r, c)
+            if val_in != 0:
+                points_in.append((r, c, val_in))
+            if val_out != 0:
+                points_out.append((r, c, val_out))
+
+    if len(points_in) != len(points_out):
+        return None
+    if not points_in:
+        return None
+
+    dy = points_out[0][0] - points_in[0][0]
+    dx = points_out[0][1] - points_in[0][1]
+    for (ri, ci, vi), (ro, co, vo) in zip(points_in, points_out):
+        if vi != vo:
+            return None
+        if ro - ri != dy or co - ci != dx:
+            return None
+    return dx, dy
+
+
+def extract_shape_based_rules(input_grid: Grid, output_grid: Grid) -> List[SymbolicRule]:
+    """Return translation rules when the entire grid is shifted."""
+    offset = _find_translation(input_grid, output_grid)
+    if offset is None:
+        return []
+
+    dx, dy = offset
+    rule = SymbolicRule(
+        transformation=Transformation(
+            TransformationType.TRANSLATE,
+            params={"dx": str(dx), "dy": str(dy)},
+        ),
+        source=[Symbol(SymbolType.REGION, "All")],
+        target=[Symbol(SymbolType.REGION, "All")],
+        nature=TransformationNature.SPATIAL,
+    )
+    return [rule]
+
+
+# ---------------------------------------------------------------------------
+# Convenience wrapper
+# ---------------------------------------------------------------------------
+
+def abstract(objects) -> List[SymbolicRule]:
+    """Return symbolic abstractions of a grid pair."""
+    if not isinstance(objects, (list, tuple)) or len(objects) < 2:
+        return []
+
+    input_grid, output_grid = objects[0], objects[1]
+    rules: List[SymbolicRule] = []
+    rules.extend(extract_color_change_rules(input_grid, output_grid))
+    rules.extend(extract_shape_based_rules(input_grid, output_grid))
+    return rules
+
+
+__all__ = [
+    "extract_color_change_rules",
+    "extract_shape_based_rules",
+    "extract_zonewise_rules",
+    "abstract",
+]

--- a/arc_solver/src/abstractions/rule_generator.py
+++ b/arc_solver/src/abstractions/rule_generator.py
@@ -1,6 +1,71 @@
-"""Generates symbolic transformation rules."""
+"""Utilities for generalizing and scoring symbolic rules."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic.vocabulary import SymbolicRule, TransformationType
 
 
-def generate_rules(abstractions):
-    """Return candidate rules."""
-    return []
+def generalize_rules(rules: List[SymbolicRule]) -> List[SymbolicRule]:
+    """Return a deduplicated list of rules.
+
+    For now the generalization step simply removes duplicate rules while
+    preserving order.
+    """
+    seen = set()
+    unique: List[SymbolicRule] = []
+    for rule in rules:
+        key = repr(rule)
+        if key not in seen:
+            seen.add(key)
+            unique.append(rule)
+    return unique
+
+
+def _coverage_for_replace(
+    rule: SymbolicRule, input_grid: Grid, output_grid: Grid
+) -> float:
+    src_color = None
+    tgt_color = None
+    for sym in rule.source:
+        if sym.type is rule.source[0].type and sym.type.name == "COLOR":
+            src_color = int(sym.value)
+            break
+    for sym in rule.target:
+        if sym.type.name == "COLOR":
+            tgt_color = int(sym.value)
+            break
+    if src_color is None or tgt_color is None:
+        return 0.0
+
+    changed = 0
+    explained = 0
+    h, w = input_grid.shape()
+    for r in range(h):
+        for c in range(w):
+            src = input_grid.get(r, c)
+            tgt = output_grid.get(r, c)
+            if src != tgt:
+                changed += 1
+                if src == src_color and tgt == tgt_color:
+                    explained += 1
+    return explained / changed if changed else 0.0
+
+
+def score_rules(
+    rules: List[SymbolicRule], input_grid: Grid, output_grid: Grid
+) -> List[Tuple[SymbolicRule, float]]:
+    """Assign a simple coverage-based score to each rule."""
+    scores: List[Tuple[SymbolicRule, float]] = []
+    for rule in rules:
+        score = 0.0
+        if rule.transformation.ttype is TransformationType.REPLACE:
+            score = _coverage_for_replace(rule, input_grid, output_grid)
+        scores.append((rule, score))
+    scores.sort(key=lambda x: x[1], reverse=True)
+    return scores
+
+
+__all__ = ["generalize_rules", "score_rules"]

--- a/arc_solver/src/abstractions/transformation_library.py
+++ b/arc_solver/src/abstractions/transformation_library.py
@@ -1,3 +1,45 @@
-"""Holds known transformations."""
+"""Library of simple symbolic transformations."""
 
-TRANSFORMATIONS = []
+from __future__ import annotations
+
+from typing import Optional
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic.vocabulary import (
+    Symbol,
+    SymbolType,
+    SymbolicRule,
+    Transformation,
+    TransformationType,
+)
+
+
+class ReplaceColor:
+    """Replace one color with another across the grid."""
+
+    @staticmethod
+    def match(input_grid: Grid, output_grid: Grid) -> Optional[SymbolicRule]:
+        from .abstractor import extract_color_change_rules
+
+        rules = extract_color_change_rules(input_grid, output_grid)
+        return rules[0] if len(rules) == 1 else None
+
+    @staticmethod
+    def apply(input_grid: Grid, rule: SymbolicRule) -> Grid:
+        if not rule.source or not rule.target:
+            return input_grid
+        src_color = int(rule.source[-1].value)
+        tgt_color = int(rule.target[-1].value)
+        result = [row[:] for row in input_grid.data]
+        out = Grid(result)
+        h, w = out.shape()
+        for r in range(h):
+            for c in range(w):
+                if out.get(r, c) == src_color:
+                    out.set(r, c, tgt_color)
+        return out
+
+
+TRANSFORMATIONS = [ReplaceColor]
+
+__all__ = ["ReplaceColor", "TRANSFORMATIONS"]

--- a/arc_solver/src/symbolic/__init__.py
+++ b/arc_solver/src/symbolic/__init__.py
@@ -9,6 +9,7 @@ from .vocabulary import (
     TransformationType,
 )
 from .rule_language import parse_rule, rule_to_dsl
+from .abstraction_dsl import rules_to_program, program_to_rules
 
 __all__ = [
     "Symbol",
@@ -19,4 +20,6 @@ __all__ = [
     "TransformationType",
     "parse_rule",
     "rule_to_dsl",
+    "rules_to_program",
+    "program_to_rules",
 ]

--- a/arc_solver/src/symbolic/abstraction_dsl.py
+++ b/arc_solver/src/symbolic/abstraction_dsl.py
@@ -1,0 +1,23 @@
+"""Helpers for composing symbolic rule programs."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .rule_language import parse_rule, rule_to_dsl
+from .vocabulary import SymbolicRule
+
+
+def rules_to_program(rules: List[SymbolicRule]) -> str:
+    """Serialize rules into a simple program string."""
+    return " | ".join(rule_to_dsl(r) for r in rules)
+
+
+def program_to_rules(text: str) -> List[SymbolicRule]:
+    """Parse a program string back into rules."""
+    if not text.strip():
+        return []
+    return [parse_rule(part.strip()) for part in text.split("|") if part.strip()]
+
+
+__all__ = ["rules_to_program", "program_to_rules"]

--- a/arc_solver/tests/test_abstraction.py
+++ b/arc_solver/tests/test_abstraction.py
@@ -1,4 +1,51 @@
-from arc_solver.src.abstractions.abstractor import abstract
+from arc_solver.src.abstractions.abstractor import (
+    abstract,
+    extract_color_change_rules,
+)
+from arc_solver.src.abstractions.rule_generator import generalize_rules
+from arc_solver.src.symbolic import (
+    rules_to_program,
+    program_to_rules,
+    Symbol,
+    SymbolType,
+    SymbolicRule,
+    Transformation,
+    TransformationType,
+)
+from arc_solver.src.core.grid import Grid
 
 def test_abstract_returns_list():
     assert isinstance(abstract([]), list)
+
+
+def test_extract_color_change_rules_simple():
+    grid_in = Grid([[1, 1], [2, 2]])
+    grid_out = Grid([[3, 3], [2, 2]])
+    rules = extract_color_change_rules(grid_in, grid_out)
+    assert any(
+        r.transformation.ttype is TransformationType.REPLACE
+        and any(s.value == "1" for s in r.source)
+        and any(t.value == "3" for t in r.target)
+        for r in rules
+    )
+
+
+def test_generalize_rules_deduplicates():
+    rule = SymbolicRule(
+        Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "2")],
+    )
+    assert len(generalize_rules([rule, rule])) == 1
+
+
+def test_dsl_roundtrip():
+    rule = SymbolicRule(
+        Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "2")],
+    )
+    program = rules_to_program([rule])
+    parsed = program_to_rules(program)
+    assert parsed == [rule]
+


### PR DESCRIPTION
## Summary
- implement a primitive symbolic abstraction engine
- add rule generalization and scoring helpers
- implement a basic transformation library
- extend symbolic DSL helpers
- include unit tests covering color rules and DSL roundtrip

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ffeda102c8322abe6ab1fe8c5f8a4