### PR TITLE
Implement Phase 3 execution and feedback modules

### DIFF
--- a/arc_solver/src/executor/__init__.py
+++ b/arc_solver/src/executor/__init__.py
@@ -1,0 +1,12 @@
+"""Execution utilities for applying symbolic rule programs."""
+
+from .simulator import simulate_rules, score_prediction
+from .conflict_resolver import resolve_conflicts
+from .predictor import select_best_program
+
+__all__ = [
+    "simulate_rules",
+    "score_prediction",
+    "resolve_conflicts",
+    "select_best_program",
+]

--- a/arc_solver/src/executor/conflict_resolver.py
+++ b/arc_solver/src/executor/conflict_resolver.py
@@ -1,6 +1,43 @@
-"""Resolves conflicts between transformations.""" 
+from __future__ import annotations
+
+"""Heuristics for resolving conflicts between symbolic rules."""
+
+from typing import Dict, List, Tuple
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic.vocabulary import SymbolType, SymbolicRule, TransformationType
 
 
-def resolve(plan):
-    """Return a resolved plan."""
-    return plan
+def _rule_key(rule: SymbolicRule) -> Tuple[str, str]:
+    """Return (ttype, src_color) key used for grouping conflicts."""
+    if rule.transformation.ttype is not TransformationType.REPLACE:
+        return (rule.transformation.ttype.value, "")
+    color = next((s.value for s in rule.source if s.type is SymbolType.COLOR), "")
+    return ("REPLACE", color)
+
+
+def _rule_complexity(rule: SymbolicRule) -> int:
+    return len(rule.source) + len(rule.target)
+
+
+def resolve_conflicts(rules: List[SymbolicRule], input_grid: Grid) -> List[SymbolicRule]:
+    """Return a new rule list with contradictions removed."""
+    groups: Dict[Tuple[str, str], List[SymbolicRule]] = {}
+    for rule in rules:
+        groups.setdefault(_rule_key(rule), []).append(rule)
+
+    resolved: List[SymbolicRule] = []
+    for key, group in groups.items():
+        if len(group) == 1 or key[0] != "REPLACE":
+            resolved.append(group[0])
+            continue
+
+        # choose rule with highest coverage (count of matching source cells)
+        src_color = int(key[1]) if key[1] else None
+        if src_color is not None:
+            coverage = sum(row.count(src_color) for row in input_grid.data)
+        else:
+            coverage = 0
+        group.sort(key=lambda r: (-coverage, _rule_complexity(r)))
+        resolved.append(group[0])
+    return resolved

--- a/arc_solver/src/executor/predictor.py
+++ b/arc_solver/src/executor/predictor.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Select the best symbolic rule program for a grid pair."""
+
+from typing import List
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.executor.simulator import simulate_rules, score_prediction
+from arc_solver.src.executor.conflict_resolver import resolve_conflicts
+from arc_solver.src.symbolic.vocabulary import SymbolicRule
+
+
+def select_best_program(
+    input_grid: Grid,
+    output_grid: Grid,
+    rule_sets: List[List[SymbolicRule]],
+) -> List[SymbolicRule]:
+    """Return the rule set with the highest simulation score."""
+    best_rules: List[SymbolicRule] = []
+    best_score = -1.0
+    for rules in rule_sets:
+        resolved = resolve_conflicts(rules, input_grid)
+        predicted = simulate_rules(input_grid, resolved)
+        score = score_prediction(predicted, output_grid)
+        if score > best_score:
+            best_score = score
+            best_rules = rules
+    return best_rules

--- a/arc_solver/src/executor/simulator.py
+++ b/arc_solver/src/executor/simulator.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Simple symbolic rule simulator for ARC grids."""
+
+from typing import List
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic.vocabulary import (
+    SymbolType,
+    SymbolicRule,
+    TransformationType,
+)
+
+
+def _apply_replace(grid: Grid, rule: SymbolicRule) -> Grid:
+    src_color = None
+    tgt_color = None
+    for sym in rule.source:
+        if sym.type is SymbolType.COLOR:
+            src_color = int(sym.value)
+            break
+    for sym in rule.target:
+        if sym.type is SymbolType.COLOR:
+            tgt_color = int(sym.value)
+            break
+    if src_color is None or tgt_color is None:
+        return grid
+
+    h, w = grid.shape()
+    new_data = [row[:] for row in grid.data]
+    for r in range(h):
+        for c in range(w):
+            if new_data[r][c] == src_color:
+                new_data[r][c] = tgt_color
+    return Grid(new_data)
+
+
+def _apply_translate(grid: Grid, rule: SymbolicRule) -> Grid:
+    try:
+        dx = int(rule.transformation.params.get("dx", "0"))
+        dy = int(rule.transformation.params.get("dy", "0"))
+    except ValueError:
+        return grid
+    h, w = grid.shape()
+    new_data = [[0 for _ in range(w)] for _ in range(h)]
+    for r in range(h):
+        for c in range(w):
+            nr = r + dy
+            nc = c + dx
+            if 0 <= nr < h and 0 <= nc < w:
+                new_data[nr][nc] = grid.data[r][c]
+    return Grid(new_data)
+
+
+def simulate_rules(input_grid: Grid, rules: List[SymbolicRule]) -> Grid:
+    """Apply a list of symbolic rules to ``input_grid``."""
+    grid = Grid([row[:] for row in input_grid.data])
+    for rule in rules:
+        if rule.transformation.ttype is TransformationType.REPLACE:
+            grid = _apply_replace(grid, rule)
+        elif rule.transformation.ttype is TransformationType.TRANSLATE:
+            grid = _apply_translate(grid, rule)
+    return grid
+
+
+def score_prediction(predicted: Grid, target: Grid) -> float:
+    """Return match ratio between ``predicted`` and ``target``."""
+    return predicted.compare_to(target)

--- a/arc_solver/src/feedback/__init__.py
+++ b/arc_solver/src/feedback/__init__.py
@@ -1,0 +1,5 @@
+"""Feedback utilities for analysing predictions."""
+
+from .correction import generate_error_signals
+
+__all__ = ["generate_error_signals"]

--- a/arc_solver/src/feedback/correction.py
+++ b/arc_solver/src/feedback/correction.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Generate high level error signals comparing predicted and target grids."""
+
+from typing import List
+
+from arc_solver.src.core.grid import Grid
+
+
+def generate_error_signals(predicted: Grid, target: Grid) -> List[str]:
+    """Return a list of textual feedback messages."""
+    messages: List[str] = []
+    if predicted.shape() != target.shape():
+        messages.append("Shape mismatch")
+        return messages
+    h, w = predicted.shape()
+    mismatches = 0
+    for r in range(h):
+        for c in range(w):
+            pv = predicted.get(r, c)
+            tv = target.get(r, c)
+            if pv != tv:
+                mismatches += 1
+                if r >= h // 2 and c >= w // 2:
+                    zone = "bottom right"
+                elif r < h // 2 and c < w // 2:
+                    zone = "top left"
+                elif r < h // 2 and c >= w // 2:
+                    zone = "top right"
+                else:
+                    zone = "bottom left"
+                messages.append(f"Color mismatch at ({r},{c}) in {zone} zone")
+    if mismatches > (h * w) // 2:
+        messages.append("Too many elements added")
+    if not mismatches:
+        messages.append("Perfect match")
+    return messages

--- a/arc_solver/src/memory/__init__.py
+++ b/arc_solver/src/memory/__init__.py
@@ -1,0 +1,5 @@
+"""Memory utilities for storing symbolic policies."""
+
+from .policy_cache import PolicyCache
+
+__all__ = ["PolicyCache"]

--- a/arc_solver/src/memory/policy_cache.py
+++ b/arc_solver/src/memory/policy_cache.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Cache of failed rule programs to avoid repetition."""
+
+from typing import Dict, List
+
+from arc_solver.src.symbolic.vocabulary import SymbolicRule
+
+
+class PolicyCache:
+    def __init__(self) -> None:
+        self._failed: Dict[str, List[List[SymbolicRule]]] = {}
+
+    def add_failure(self, task_hash: str, ruleset: List[SymbolicRule]) -> None:
+        self._failed.setdefault(task_hash, []).append(list(ruleset))
+
+    def is_failed(self, task_hash: str, ruleset: List[SymbolicRule]) -> bool:
+        failed = self._failed.get(task_hash, [])
+        for rs in failed:
+            if len(rs) == len(ruleset) and all(a == b for a, b in zip(rs, ruleset)):
+                return True
+        return False

--- a/arc_solver/src/search/__init__.py
+++ b/arc_solver/src/search/__init__.py
@@ -1,0 +1,5 @@
+"""Search utilities for exploring rule programs."""
+
+from .rule_ranker import rank_rule_sets
+
+__all__ = ["rank_rule_sets"]

--- a/arc_solver/src/search/rule_ranker.py
+++ b/arc_solver/src/search/rule_ranker.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Simple heuristics for ranking sets of symbolic rules."""
+
+from typing import List
+
+from arc_solver.src.memory.policy_cache import PolicyCache
+from arc_solver.src.symbolic.vocabulary import SymbolicRule
+
+
+def rank_rule_sets(
+    rule_sets: List[List[SymbolicRule]],
+    policy_cache: PolicyCache | None = None,
+    task_hash: str | None = None,
+) -> List[List[SymbolicRule]]:
+    """Return ``rule_sets`` sorted by heuristic score."""
+
+    def score(rs: List[SymbolicRule]) -> tuple:
+        coverage = len(rs)
+        diversity = len({r.transformation.ttype for r in rs})
+        abstractness = -sum(len(r.source) + len(r.target) for r in rs)
+        reuse = 0
+        if policy_cache and task_hash and policy_cache.is_failed(task_hash, rs):
+            reuse = -1
+        return (reuse, coverage, diversity, abstractness)
+
+    return sorted(rule_sets, key=score, reverse=True)

--- a/arc_solver/tests/test_phase3.py
+++ b/arc_solver/tests/test_phase3.py
@@ -1,0 +1,76 @@
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.executor import (
+    simulate_rules,
+    score_prediction,
+    resolve_conflicts,
+    select_best_program,
+)
+from arc_solver.src.feedback import generate_error_signals
+from arc_solver.src.memory import PolicyCache
+from arc_solver.src.search import rank_rule_sets
+from arc_solver.src.symbolic import (
+    Symbol,
+    SymbolType,
+    SymbolicRule,
+    Transformation,
+    TransformationType,
+)
+
+
+def _color_rule(src: int, tgt: int) -> SymbolicRule:
+    return SymbolicRule(
+        Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, str(src))],
+        target=[Symbol(SymbolType.COLOR, str(tgt))],
+    )
+
+
+def test_simulate_replace_and_score():
+    grid = Grid([[1, 2], [1, 0]])
+    rule = _color_rule(1, 3)
+    pred = simulate_rules(grid, [rule])
+    assert pred.data[0][0] == 3
+    target = Grid([[3, 2], [3, 0]])
+    assert score_prediction(pred, target) == 1.0
+
+
+def test_conflict_resolver_prefers_simple():
+    grid = Grid([[1, 1], [2, 2]])
+    simple = _color_rule(1, 3)
+    complex_rule = SymbolicRule(
+        Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.ZONE, "Z"), Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "2")],
+    )
+    resolved = resolve_conflicts([complex_rule, simple], grid)
+    assert resolved[0] == simple
+
+
+def test_select_best_program():
+    grid_in = Grid([[1, 1], [0, 0]])
+    grid_out = Grid([[2, 2], [0, 0]])
+    good = [_color_rule(1, 2)]
+    bad = [_color_rule(1, 3)]
+    best = select_best_program(grid_in, grid_out, [bad, good])
+    assert best == good
+
+
+def test_generate_error_signals():
+    pred = Grid([[1]])
+    target = Grid([[2]])
+    msgs = generate_error_signals(pred, target)
+    assert any("Color mismatch" in m for m in msgs)
+
+
+def test_policy_cache():
+    cache = PolicyCache()
+    ruleset = [_color_rule(1, 2)]
+    cache.add_failure("task", ruleset)
+    assert cache.is_failed("task", ruleset)
+
+
+def test_rule_ranker():
+    rs1 = [_color_rule(1, 2), _color_rule(2, 3)]
+    rs2 = [_color_rule(1, 2)]
+    ranked = rank_rule_sets([rs2, rs1])
+    assert ranked[0] == rs1


### PR DESCRIPTION
## Summary
- implement symbolic simulator and scoring functions
- add conflict resolution heuristics
- select best rule program via predictor
- generate basic feedback error messages
- cache failed rule sets
- rank rule permutations with heuristic score
- export utilities from package initializers
- add comprehensive tests for new modules

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840012b74948322a996f085b8c8323c