### PR TITLE
Enhance trace validation and narration

### DIFF
--- a/arc_solver/src/introspection/__init__.py
+++ b/arc_solver/src/introspection/__init__.py
@@ -1,0 +1,8 @@
+
+"""Introspection utilities for tracing and explaining solver behaviour."""
+
+from .trace_builder import RuleTrace, build_trace
+from .introspective_validator import validate_trace
+from .narrator_llm import narrate_trace
+
+__all__ = ["RuleTrace", "build_trace", "validate_trace", "narrate_trace"]

--- a/arc_solver/src/introspection/introspective_validator.py
+++ b/arc_solver/src/introspection/introspective_validator.py
@@ -1,6 +1,92 @@
-"""Validates solver steps using introspection."""
+"""Heuristics for validating symbolic execution traces.
+
+`validate_trace` analyses a :class:`RuleTrace` and returns a structured
+dictionary describing how well the rule's output matches the ground truth.
+The metrics attempt to capture whether the rule was applied in the correct
+symbolic region and if any semantic conflicts occurred during execution.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .trace_builder import RuleTrace
 
 
-def validate(plan):
-    """Return a validation result."""
-    return True
+def validate_trace(trace: RuleTrace) -> Dict[str, Any]:
+    """Return validation metrics for ``trace``.
+
+    The returned dictionary has the following keys::
+
+        {
+            "coverage_score": float,
+            "correct_cells": int,
+            "total_cells": int,
+            "symbolic_consistency": bool,
+            "conflict_flags": List[str],
+            "interpretation_valid": bool,
+        }
+    """
+
+    height, width = trace.predicted_grid.shape()
+    total_cells = height * width
+
+    # ------------------------------------------------------------------
+    # Evaluate cell level agreement with the ground truth
+    # ------------------------------------------------------------------
+    mismatched: List[tuple[int, int]] = []
+    if trace.ground_truth is not None:
+        for r in range(height):
+            for c in range(width):
+                if trace.delta_mask[r][c]:
+                    mismatched.append((r, c))
+
+    correct_cells = total_cells - len(mismatched)
+    coverage_score = correct_cells / total_cells if total_cells else 1.0
+
+    # ------------------------------------------------------------------
+    # Symbolic consistency heuristics
+    # ------------------------------------------------------------------
+    # ``symbolically_matched`` is True when all mismatched cells were within the
+    # set of cells transformed by the rule.  In this case the rule logically
+    # targeted the right area but produced the wrong pixel values.
+    symbolically_matched = all(loc in trace.affected_cells for loc in mismatched)
+    symbolic_consistency = symbolically_matched
+
+    # Determine simple conflict flags
+    conflict_flags: List[str] = []
+
+    if mismatched and symbolically_matched:
+        conflict_flags.append("visual_failure")
+    elif mismatched and not symbolically_matched:
+        conflict_flags.append("structural_mismatch")
+
+    # Detect repeated region labels in the symbolic context
+    labels = trace.symbolic_context.get("labels", {})
+    if labels:
+        region_count: Dict[str, int] = {}
+        for labs in labels.values():
+            for lab in labs:
+                region_count[lab] = region_count.get(lab, 0) + 1
+        for label, count in region_count.items():
+            if count > len(labels):
+                conflict_flags.append("region_repeated")
+                break
+
+    # ``interpretation_valid`` approximates whether the rule behaved as
+    # intended. High coverage and no conflicts imply success.
+    interpretation_valid = (
+        coverage_score >= 0.99 and symbolic_consistency and not conflict_flags
+    )
+
+    return {
+        "coverage_score": coverage_score,
+        "correct_cells": correct_cells,
+        "total_cells": total_cells,
+        "symbolic_consistency": symbolic_consistency,
+        "conflict_flags": conflict_flags,
+        "interpretation_valid": interpretation_valid,
+    }
+
+
+__all__ = ["validate_trace"]

--- a/arc_solver/src/introspection/narrator_llm.py
+++ b/arc_solver/src/introspection/narrator_llm.py
@@ -1,6 +1,92 @@
-"""LLM-based narrative descriptions."""
+"""Generate natural language explanations for rule traces.
+
+The :func:`narrate_trace` helper converts a :class:`RuleTrace` and the
+associated validation metrics into a concise text description.  If the
+``openai`` package is available a GPT completion can be used for richer
+language, otherwise a deterministic summary string is returned.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from .trace_builder import RuleTrace
+from .introspective_validator import validate_trace
+
+try:  # pragma: no cover - optional dependency
+    import openai
+except Exception:  # pragma: no cover - if openai is unavailable
+    openai = None
 
 
-def narrate(plan):
-    """Return a narration for the given plan."""
-    return ""
+_PROMPT_TEMPLATE = (
+    "You are a symbolic reasoning assistant analysing a transformation rule applied to a grid.\n"
+    "Rule: {rule}\n"
+    "Affected cells: {cells}\n"
+    "Metrics: {metrics}\n"
+    "Symbolic context: {context}\n"
+    "Provide a concise explanation of the rule's effect, coverage and any conflicts."
+)
+
+
+def narrate_trace(
+    trace: RuleTrace, *, model: str = "gpt-4", use_llm: bool = False
+) -> str:
+    """Return a natural language summary for ``trace``.
+
+    Parameters
+    ----------
+    trace:
+        The rule execution trace.
+    model:
+        GPT model to use when ``use_llm`` is ``True`` and ``openai`` is
+        available.
+    use_llm:
+        When ``True`` and ``openai`` is installed, use GPT to craft the
+        narrative.  Otherwise a deterministic summary string is returned.
+    """
+
+    metrics: Dict[str, Any] = validate_trace(trace)
+
+    prompt = _PROMPT_TEMPLATE.format(
+        rule=str(trace.rule),
+        cells=json.dumps(trace.affected_cells),
+        metrics=json.dumps(metrics),
+        context=json.dumps(trace.symbolic_context),
+    )
+
+    if openai is not None and use_llm:
+        try:  # pragma: no cover - optional external call
+            response = openai.ChatCompletion.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return response["choices"][0]["message"]["content"].strip()
+        except Exception:  # pragma: no cover - fall back if API fails
+            pass
+
+    # ------------------------------------------------------------------
+    # Deterministic fallback summary
+    # ------------------------------------------------------------------
+    zones = ", ".join(trace.symbolic_context.get("zones", []))
+    regions = ", ".join(trace.symbolic_context.get("regions", []))
+
+    parts = [f"Rule {trace.rule} affected {len(trace.affected_cells)} cells"]
+    if zones:
+        parts.append(f"in zones {zones}")
+    if regions:
+        parts.append(f"across regions {regions}")
+
+    coverage_pct = metrics["coverage_score"] * 100
+    if metrics["interpretation_valid"]:
+        parts.append("with full coverage")
+    else:
+        parts.append(f"covering {coverage_pct:.1f}% of the grid")
+        if metrics["conflict_flags"]:
+            parts.append(f"conflicts: {', '.join(metrics['conflict_flags'])}")
+
+    return " ".join(parts) + "."
+
+
+__all__ = ["narrate_trace"]

--- a/arc_solver/src/introspection/trace_builder.py
+++ b/arc_solver/src/introspection/trace_builder.py
@@ -1,6 +1,87 @@
-"""Builds solver traces for introspection."""
+"""Utilities for constructing symbolic execution traces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic.vocabulary import Symbol, SymbolType, SymbolicRule
 
 
-def build_trace(actions):
-    """Return a structured trace."""
-    return []
+@dataclass
+class RuleTrace:
+    """Structured record of a single symbolic rule application."""
+
+    rule: SymbolicRule
+    affected_cells: List[Tuple[int, int]]
+    predicted_grid: Grid
+    ground_truth: Optional[Grid]
+    delta_mask: List[List[bool]]
+    match_score: float
+    symbolic_context: Dict[str, Any] = field(default_factory=dict)
+
+
+def build_trace(
+    rule: SymbolicRule,
+    grid_in: Grid,
+    grid_out: Grid,
+    grid_true: Optional[Grid],
+    symbolic_overlay: Optional[List[List[Symbol]]] = None,
+) -> RuleTrace:
+    """Return a :class:`RuleTrace` describing ``rule``'s effect."""
+
+    height, width = grid_in.shape()
+
+    affected: List[Tuple[int, int]] = []
+    for r in range(height):
+        for c in range(width):
+            if grid_in.get(r, c) != grid_out.get(r, c):
+                affected.append((r, c))
+
+    if grid_true is not None and grid_true.shape() == grid_out.shape():
+        delta_mask = [
+            [grid_out.get(r, c) != grid_true.get(r, c) for c in range(width)]
+            for r in range(height)
+        ]
+        match_score = grid_out.compare_to(grid_true)
+    else:
+        delta_mask = [[False for _ in range(width)] for _ in range(height)]
+        match_score = 1.0 if grid_true is None else 0.0
+
+    context: Dict[str, Any] = {}
+    if symbolic_overlay is not None and len(symbolic_overlay) == height:
+        zones: set[str] = set()
+        regions: set[str] = set()
+        cell_labels: Dict[Tuple[int, int], List[str]] = {}
+        for r, c in affected:
+            syms = symbolic_overlay[r][c]
+            if syms is None:
+                continue
+            if not isinstance(syms, list):
+                syms = [syms]
+            cell_labels[(r, c)] = [str(s) for s in syms]
+            for s in syms:
+                if s.type is SymbolType.ZONE:
+                    zones.add(s.value)
+                elif s.type is SymbolType.REGION:
+                    regions.add(s.value)
+        if zones:
+            context["zones"] = sorted(zones)
+        if regions:
+            context["regions"] = sorted(regions)
+        if cell_labels:
+            context["labels"] = cell_labels
+
+    return RuleTrace(
+        rule=rule,
+        affected_cells=affected,
+        predicted_grid=grid_out,
+        ground_truth=grid_true,
+        delta_mask=delta_mask,
+        match_score=match_score,
+        symbolic_context=context,
+    )
+
+
+__all__ = ["RuleTrace", "build_trace"]

--- a/arc_solver/tests/test_introspection.py
+++ b/arc_solver/tests/test_introspection.py
@@ -1,0 +1,40 @@
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic import (
+    Symbol,
+    SymbolType,
+    SymbolicRule,
+    Transformation,
+    TransformationType,
+)
+from arc_solver.src.introspection import build_trace, validate_trace, narrate_trace
+
+
+def _color_rule(src: int, tgt: int) -> SymbolicRule:
+    return SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, str(src))],
+        target=[Symbol(SymbolType.COLOR, str(tgt))],
+    )
+
+
+def test_validate_trace_metrics():
+    grid_in = Grid([[1, 1], [1, 1]])
+    rule = _color_rule(1, 2)
+    pred = Grid([[2, 1], [2, 1]])
+    true = Grid([[2, 2], [2, 2]])
+    trace = build_trace(rule, grid_in, pred, true)
+    metrics = validate_trace(trace)
+    assert metrics["total_cells"] == 4
+    assert metrics["correct_cells"] == 2
+    assert metrics["symbolic_consistency"] is False
+    assert "structural_mismatch" in metrics["conflict_flags"]
+
+
+def test_narrate_trace_fallback():
+    grid = Grid([[1]])
+    rule = _color_rule(1, 2)
+    pred = Grid([[2]])
+    trace = build_trace(rule, grid, pred, pred)
+    summary = narrate_trace(trace)
+    assert "Rule" in summary
+    assert "full coverage" in summary

--- a/arc_solver/tests/test_llm_tracer.py
+++ b/arc_solver/tests/test_llm_tracer.py
@@ -1,4 +1,0 @@
-from arc_solver.src.introspection.trace_builder import build_trace
-
-def test_trace_builder_empty():
-    assert build_trace([]) == []


### PR DESCRIPTION
## Summary
- overhaul `validate_trace` to output coverage metrics and conflict flags
- improve `narrate_trace` with deterministic summaries and optional GPT support
- expose introspection utilities cleanly
- add new unit tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684008e070fc83229c7d1b3c74c7d3c1