### PR TITLE
Fix AGI dataset handling

### DIFF
--- a/arc_solver/src/core/grid.py
+++ b/arc_solver/src/core/grid.py
@@ -66,6 +66,10 @@ class Grid:
         flipped = [list(reversed(row)) for row in self.data]
         return Grid(flipped)
 
+    def to_list(self) -> List[List[int]]:
+        """Return a deep list copy of the grid data."""
+        return [row[:] for row in self.data]
+
     def attach_overlay(self, overlay: List[List[Any]]) -> None:
         """Attach a symbolic overlay to the grid."""
         h, w = self.shape()

--- a/arc_solver/src/evaluation/submission_builder.py
+++ b/arc_solver/src/evaluation/submission_builder.py
@@ -13,7 +13,12 @@ def build_submission_json(tasks: List[ARCAGITask], predictions: Dict[tuple[str, 
 
     submission: Dict[str, Dict[str, List[List[int]] | List[List[List[int]]]]] = {}
     for task in tasks:
-        outputs = [predictions[(task.task_id, i)].to_list() for i in range(len(task.test))]
+        outputs: List[List[List[int]]] = []
+        for i in range(len(task.test)):
+            key = (task.task_id, i)
+            if key not in predictions:
+                raise KeyError(f"Missing prediction for {task.task_id} index {i}")
+            outputs.append(predictions[key].data)
         submission[task.task_id] = {
             "output": outputs if len(outputs) > 1 else outputs[0]
         }

--- a/arc_solver/tests/test_run_agi_solver.py
+++ b/arc_solver/tests/test_run_agi_solver.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import sys
+from arc_solver.scripts.run_agi_solver import main
+
+
+def test_run_agi_solver_creates_submission(tmp_path, monkeypatch):
+    data_dir = tmp_path
+    out_file = tmp_path / "submission.json"
+    # Only underscore filename provided
+    src = Path(__file__).with_name("sample_agi-challenges.json")
+    (data_dir / "arc-agi_training_challenges.json").write_text(src.read_text())
+
+    argv = [
+        "prog",
+        "--split",
+        "train",
+        "--data_dir",
+        str(data_dir),
+        "--output",
+        str(out_file),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    main()
+    assert out_file.exists()
+


### PR DESCRIPTION
## Summary
- update `agi_loader` to unwrap AGI dataset grids and validate inputs
- add `Grid.to_list` helper
- make `submission_builder` robust to missing predictions
- improve `run_agi_solver` CLI and dataset lookup
- regression test for running the solver

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68401ef21b4c83229963dd9104f3aae2