### PR TITLE
Improve ARC evaluation robustness

### DIFF
--- a/arc_solver/scripts/recover_predictions.py
+++ b/arc_solver/scripts/recover_predictions.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Regenerate predictions for tasks missing from a prediction JSON file."""
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+from arc_solver.src.executor.full_pipeline import solve_task
+from arc_solver.scripts.utils import iter_arc_task_files
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Recover missing ARC predictions")
+    parser.add_argument("existing", type=Path, help="Existing predictions JSON")
+    parser.add_argument("tasks", type=Path, help="Directory of ARC task JSON files")
+    parser.add_argument("--output", type=Path, default="merged_predictions.json", help="Output path for merged predictions")
+    args = parser.parse_args()
+
+    preds: dict[str, dict] = {}
+    if args.existing.exists():
+        preds = json.loads(args.existing.read_text())
+
+    for tid, task, skipped in iter_arc_task_files(args.tasks):
+        if skipped:
+            continue
+        if tid in preds and preds[tid].get("output"):
+            continue
+        try:
+            outputs, _, _, _ = solve_task(task)
+            preds[tid] = {"output": [g.data for g in outputs]}
+        except Exception as exc:
+            print(f"[ERROR] Task {tid} — exception during solve(): {exc}", file=sys.stderr)
+
+    args.output.write_text(json.dumps(preds))
+    print(f"Merged predictions written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/arc_solver/scripts/utils.py
+++ b/arc_solver/scripts/utils.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Helper utilities for command line scripts."""
+
+from pathlib import Path
+import sys
+from typing import Iterable, Tuple, Dict, Any
+
+from arc_solver.src.data.arc_dataset import load_arc_task
+
+
+def iter_arc_task_files(directory: Path) -> Iterable[Tuple[str, Dict[str, Any], bool]]:
+    """Yield ``(task_id, json_obj, skipped)`` for each task in ``directory``.
+
+    Files missing a ``test`` field or with an empty ``test`` list are skipped and
+    logged. ``skipped`` indicates whether the task was ignored.
+    """
+    for path in sorted(Path(directory).glob("*.json")):
+        tid = path.stem
+        try:
+            task = load_arc_task(path)
+        except Exception as exc:
+            print(f"[ERROR] Failed to load {tid}: {exc}", file=sys.stderr)
+            continue
+        if not task.get("test"):
+            print(f"[SKIP] Task {tid} — no test set available.", file=sys.stderr)
+            yield tid, task, True
+            continue
+        yield tid, task, False


### PR DESCRIPTION
## Summary
- add a reusable helper to iterate over all JSON tasks, skipping those without tests
- update solver script to use new loader with error handling
- make evaluation script resilient to missing or malformed predictions
- provide a recovery tool for regenerating missing predictions

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402a168cc48322857ee7b3d0163d25