### PR TITLE
Add zone-aware conditional rule support

### DIFF
--- a/arc_solver/src/introspection/trace_builder.py
+++ b/arc_solver/src/introspection/trace_builder.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from arc_solver.src.core.grid import Grid
 from arc_solver.src.symbolic.vocabulary import Symbol, SymbolType, SymbolicRule
+from arc_solver.src.segment.segmenter import zone_overlay
 
 
 @dataclass
@@ -50,6 +51,11 @@ def build_trace(
         match_score = 1.0 if grid_true is None else 0.0
 
     context: Dict[str, Any] = {}
+    if rule.condition:
+        context["condition"] = dict(rule.condition)
+    if symbolic_overlay is None and rule.condition.get("zone"):
+        symbolic_overlay = zone_overlay(grid_in)
+
     if symbolic_overlay is not None and len(symbolic_overlay) == height:
         zones: set[str] = set()
         regions: set[str] = set()

--- a/arc_solver/src/segment/__init__.py
+++ b/arc_solver/src/segment/__init__.py
@@ -2,7 +2,13 @@
 
 from typing import Any, List
 
-from .segmenter import assign_zone_labels, segment_connected_regions, segment_fixed_zones
+from .segmenter import (
+    assign_zone_labels,
+    segment_connected_regions,
+    segment_fixed_zones,
+    zone_overlay,
+    label_connected_regions,
+)
 
 
 def segment(grid: Any) -> List:
@@ -13,5 +19,7 @@ __all__ = [
     "segment_fixed_zones",
     "segment_connected_regions",
     "assign_zone_labels",
+    "zone_overlay",
+    "label_connected_regions",
     "segment",
 ]

--- a/arc_solver/src/segment/segmenter.py
+++ b/arc_solver/src/segment/segmenter.py
@@ -90,6 +90,27 @@ def segment_connected_regions(grid: Grid) -> Dict[int, List[Tuple[int, int]]]:
 
 
 # ---------------------------------------------------------------------------
+# Overlay utilities
+# ---------------------------------------------------------------------------
+
+def zone_overlay(grid: Grid) -> List[List[Optional[Symbol]]]:
+    """Return zone label overlay matrix for ``grid``."""
+    zones = segment_fixed_zones(grid)
+    return assign_zone_labels(grid, zones)
+
+
+def label_connected_regions(grid: Grid) -> List[List[Optional[int]]]:
+    """Return integer region labels overlay for connected components."""
+    regions = segment_connected_regions(grid)
+    height, width = grid.shape()
+    overlay: List[List[Optional[int]]] = [[None for _ in range(width)] for _ in range(height)]
+    for reg_id, cells in regions.items():
+        for r, c in cells:
+            overlay[r][c] = reg_id
+    return overlay
+
+
+# ---------------------------------------------------------------------------
 # Zone overlay assignment
 # ---------------------------------------------------------------------------
 
@@ -110,4 +131,6 @@ __all__ = [
     "segment_fixed_zones",
     "segment_connected_regions",
     "assign_zone_labels",
+    "zone_overlay",
+    "label_connected_regions",
 ]

--- a/arc_solver/src/symbolic/vocabulary.py
+++ b/arc_solver/src/symbolic/vocabulary.py
@@ -90,6 +90,7 @@ class SymbolicRule:
     source: List[Symbol]
     target: List[Symbol]
     nature: TransformationNature | None = None
+    condition: Dict[str, str] = field(default_factory=dict)
 
     def __str__(self) -> str:
         left = ", ".join(str(s) for s in self.source)
@@ -102,7 +103,8 @@ class SymbolicRule:
             "SymbolicRule("
             f"transformation={self.transformation!r}, "
             f"source={self.source!r}, "
-            f"target={self.target!r}, nature={self.nature!r})"
+            f"target={self.target!r}, "
+            f"nature={self.nature!r}, condition={self.condition!r})"
         )
 
 

--- a/arc_solver/tests/test_zone_rules.py
+++ b/arc_solver/tests/test_zone_rules.py
@@ -1,0 +1,24 @@
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.executor.simulator import simulate_rules
+from arc_solver.src.symbolic import Symbol, SymbolType, SymbolicRule, Transformation, TransformationType
+
+
+def test_replace_zone_condition():
+    grid = Grid([
+        [1, 1, 1],
+        [1, 1, 1],
+        [1, 1, 1],
+    ])
+    rule = SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "2")],
+        condition={"zone": "TopLeft"},
+    )
+    pred = simulate_rules(grid, [rule])
+    assert pred.get(0, 0) == 2
+    for r in range(3):
+        for c in range(3):
+            if (r, c) == (0, 0):
+                continue
+            assert pred.get(r, c) == 1


### PR DESCRIPTION
## Summary
- support segmentation zone overlay and connected region labels
- attach optional condition to `SymbolicRule`
- extract color change rules with zone awareness
- update rule simulation to respect `.condition`
- enhance trace builder with overlay context
- tests for zone-conditioned replace

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684038f987788322b83177efc42be9c8