### PR TITLE
Phase 6 cognitive control implementation

### DIFF
--- a/arc_solver/src/executor/attention.py
+++ b/arc_solver/src/executor/attention.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.segment.segmenter import zone_overlay
+
+
+class AttentionMask:
+    """Binary mask specifying active grid cells."""
+
+    def __init__(self, shape: Tuple[int, int]):
+        h, w = shape
+        self.mask: List[List[bool]] = [[True for _ in range(w)] for _ in range(h)]
+
+    def focus_zone(self, grid: Grid, zone_label: str) -> None:
+        """Activate only cells belonging to ``zone_label``."""
+        overlay = zone_overlay(grid)
+        h, w = grid.shape()
+        self.mask = [
+            [overlay[r][c] is not None and overlay[r][c].value == zone_label for c in range(w)]
+            for r in range(h)
+        ]
+
+    def as_list(self) -> List[List[bool]]:
+        return [row[:] for row in self.mask]
+
+
+def zone_to_mask(grid: Grid, zone_label: str) -> List[List[bool]]:
+    mask = AttentionMask(grid.shape())
+    mask.focus_zone(grid, zone_label)
+    return mask.as_list()
+
+
+__all__ = ["AttentionMask", "zone_to_mask"]

--- a/arc_solver/src/executor/dependency.py
+++ b/arc_solver/src/executor/dependency.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, List, Set
+
+from arc_solver.src.symbolic.vocabulary import (
+    SymbolType,
+    SymbolicRule,
+    TransformationType,
+)
+
+
+class RuleDependencyGraph:
+    """Simple undirected conflict graph between rules."""
+
+    def __init__(self, rules: List[SymbolicRule]) -> None:
+        self.edges: Dict[int, Set[int]] = defaultdict(set)
+        self.build(rules)
+
+    def build(self, rules: List[SymbolicRule]) -> None:
+        for i, r1 in enumerate(rules):
+            for j, r2 in enumerate(rules):
+                if i >= j:
+                    continue
+                if has_conflict(r1, r2):
+                    self.edges[i].add(j)
+                    self.edges[j].add(i)
+
+
+def _extract_color(rule: SymbolicRule) -> str | None:
+    for sym in rule.target:
+        if sym.type is SymbolType.COLOR:
+            return sym.value
+    return None
+
+
+def has_conflict(r1: SymbolicRule, r2: SymbolicRule) -> bool:
+    zone1 = r1.condition.get("zone") if r1.condition else None
+    zone2 = r2.condition.get("zone") if r2.condition else None
+    if zone1 and zone2 and zone1 != zone2:
+        return False
+
+    if (
+        r1.transformation.ttype is TransformationType.REPLACE
+        and r2.transformation.ttype is TransformationType.REPLACE
+    ):
+        src1 = [s.value for s in r1.source if s.type is SymbolType.COLOR]
+        src2 = [s.value for s in r2.source if s.type is SymbolType.COLOR]
+        tgt1 = _extract_color(r1)
+        tgt2 = _extract_color(r2)
+        if src1 and src2 and src1 == src2 and tgt1 != tgt2:
+            return True
+    return False
+
+
+def select_independent_rules(rules: List[SymbolicRule]) -> List[SymbolicRule]:
+    graph = RuleDependencyGraph(rules)
+    chosen: List[SymbolicRule] = []
+    for idx, rule in enumerate(rules):
+        if any(j in graph.edges.get(idx, set()) for j in range(len(chosen))):
+            continue
+        chosen.append(rule)
+    return chosen
+
+
+__all__ = ["RuleDependencyGraph", "has_conflict", "select_independent_rules"]

--- a/arc_solver/tests/test_phase6.py
+++ b/arc_solver/tests/test_phase6.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic.vocabulary import (
+    Symbol,
+    SymbolType,
+    SymbolicRule,
+    Transformation,
+    TransformationType,
+)
+from arc_solver.src.executor.simulator import simulate_rules
+from arc_solver.src.executor.attention import zone_to_mask
+from arc_solver.src.executor.dependency import select_independent_rules
+
+
+def test_reflex_override_symmetry():
+    grid = Grid([[1, 1, 1], [1, 1, 1], [1, 1, 1]])
+    rule = SymbolicRule(
+        Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "2")],
+        condition={"zone": "TopLeft"},
+    )
+    pred = simulate_rules(grid, [rule])
+    assert pred.data == grid.data
+
+
+def test_attention_mask_zone():
+    grid = Grid([[1, 0, 2], [1, 1, 1], [1, 1, 1]])
+    mask = zone_to_mask(grid, "TopLeft")
+    rule = SymbolicRule(
+        Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "3")],
+    )
+    pred = simulate_rules(grid, [rule], attention_mask=mask)
+    assert pred.get(0, 0) == 3
+    for r in range(3):
+        for c in range(3):
+            if (r, c) == (0, 0):
+                continue
+            assert pred.get(r, c) == grid.get(r, c)
+
+
+def test_dependency_graph_select():
+    r1 = SymbolicRule(
+        Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "2")],
+    )
+    r2 = SymbolicRule(
+        Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "3")],
+    )
+    selected = select_independent_rules([r1, r2])
+    assert len(selected) == 1

--- a/arc_solver/tests/test_zone_rules.py
+++ b/arc_solver/tests/test_zone_rules.py
@@ -16,9 +16,7 @@ def test_replace_zone_condition():
         condition={"zone": "TopLeft"},
     )
     pred = simulate_rules(grid, [rule])
-    assert pred.get(0, 0) == 2
+    # Symmetry violation triggers reflex override; grid remains unchanged
     for r in range(3):
         for c in range(3):
-            if (r, c) == (0, 0):
-                continue
             assert pred.get(r, c) == 1


### PR DESCRIPTION
## Summary
- add reflex override logic to simulator
- implement attention masks for zone-aware focus
- add rule dependency graph to prune conflicting rules
- integrate attention and dependency handling in solving pipeline
- test reflex overrides, attention masks and dependency pruning
- update zone rule test for new behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840400125b48322a1cc4635ccd3a2fa