### PR TITLE
Add dual prediction format and fail‑safe pipeline

### DIFF
--- a/arc_solver/tests/test_run_agi_solver.py
+++ b/arc_solver/tests/test_run_agi_solver.py
@@ -25,5 +25,5 @@ def test_run_agi_solver_creates_submission(tmp_path, monkeypatch):
     assert out_file.exists()
     data = json.loads(out_file.read_text())
     assert "00000001" in data
-    assert data["00000001"]["output"] == [[1]]
+    assert data["00000001"]["output"] == [[[[1]], [[1]]]]
 


### PR DESCRIPTION
## Summary
- ensure `build_submission_json` always outputs two predictions per test case
- provide fallback duplication and shape validation
- harden `solve_task` pipeline with try/catch wrappers
- fall back to prior templates or default predictor on failure
- adapt unit test for new submission format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f8bdf6dc83229c6e74d7561b7683