### PR TITLE
Add structural attention framework

### DIFF
--- a/arc_solver/configs/meta_config.yaml
+++ b/arc_solver/configs/meta_config.yaml
@@ -12,3 +12,5 @@ prior_injection:
   use_motifs: true
   inject_from_memory: true
   fallback_only: false
+use_structural_attention: true
+structural_attention_weight: 0.2

--- a/arc_solver/scripts/run_agi_solver.py
+++ b/arc_solver/scripts/run_agi_solver.py
@@ -212,6 +212,8 @@ def main() -> None:
     parser.add_argument("--use_deep_priors", action="store_true", help="Enable deep prior injection")
     parser.add_argument("--prior_threshold", type=float, default=0.4, help="Signature similarity threshold")
     parser.add_argument("--motif_file", type=str, default=None, help="Motif library YAML")
+    parser.add_argument("--use_structural_attention", action="store_true", help="Enable structural attention")
+    parser.add_argument("--attention_weight", type=float, default=0.2, help="Structural attention weight")
     parser.add_argument("--reflex_override", action="store_true", help="Enable regime override")
     parser.add_argument("--regime_threshold", type=float, default=0.45, help="Override threshold")
     parser.add_argument(
@@ -241,6 +243,8 @@ def main() -> None:
     config_loader.set_regime_threshold(args.regime_threshold)
     config_loader.set_prior_injection(args.use_deep_priors)
     config_loader.set_prior_threshold(int(args.prior_threshold))
+    config_loader.set_use_structural_attention(args.use_structural_attention)
+    config_loader.set_attention_weight(args.attention_weight)
 
     split_prefix = {
         "train": "arc-agi_training",

--- a/arc_solver/src/attention/__init__.py
+++ b/arc_solver/src/attention/__init__.py
@@ -1,0 +1,13 @@
+"""Hybrid symbolic attention utilities."""
+
+from .structural_encoder import StructuralEncoder
+from .symbolic_attention import SymbolicAttention
+from .fusion_injector import apply_structural_attention
+from .grid_feature_extractor import color_histogram
+
+__all__ = [
+    "StructuralEncoder",
+    "SymbolicAttention",
+    "apply_structural_attention",
+    "color_histogram",
+]

--- a/arc_solver/src/attention/fusion_injector.py
+++ b/arc_solver/src/attention/fusion_injector.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Utilities to inject structural attention into rule ranking."""
+
+from typing import List, Tuple
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.segment.segmenter import zone_overlay
+from arc_solver.src.attention.structural_encoder import StructuralEncoder
+from arc_solver.src.attention.symbolic_attention import SymbolicAttention
+
+
+_DEF_DIM = 32
+
+
+def apply_structural_attention(
+    grid: Grid, ranked_rules: List[Tuple[List, float]], weight: float = 0.2
+) -> List[Tuple[List, float]]:
+    """Return attention-modulated ``ranked_rules``."""
+
+    overlay = zone_overlay(grid)
+    encoder = StructuralEncoder(dim=_DEF_DIM)
+    context = encoder.encode([[z.value if z else None for z in row] for row in overlay])
+    attention = SymbolicAttention(weight=weight, dim=_DEF_DIM)
+    return attention.apply(ranked_rules, context)
+
+
+__all__ = ["apply_structural_attention"]

--- a/arc_solver/src/attention/grid_feature_extractor.py
+++ b/arc_solver/src/attention/grid_feature_extractor.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Basic grid feature extractor used for optional conditioning."""
+
+from typing import List
+
+import numpy as np
+
+from arc_solver.src.core.grid import Grid
+
+
+def color_histogram(grid: Grid, dim: int = 16) -> List[float]:
+    """Return normalized color histogram of ``grid``."""
+
+    counts = grid.count_colors()
+    total = grid.shape()[0] * grid.shape()[1]
+    vec = np.zeros(dim, dtype=float)
+    for color, count in counts.items():
+        vec[color % dim] += count / float(total)
+    return vec.tolist()
+
+
+__all__ = ["color_histogram"]

--- a/arc_solver/src/attention/structural_encoder.py
+++ b/arc_solver/src/attention/structural_encoder.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Simple structural context encoder for ARC grids."""
+
+from typing import List, Optional
+
+import numpy as np
+
+
+class StructuralEncoder:
+    """Encode symbolic overlays and masks into a dense vector."""
+
+    def __init__(self, dim: int = 32) -> None:
+        self.dim = dim
+
+    def _embed_token(self, token: str) -> np.ndarray:
+        rng = np.random.default_rng(abs(hash(token)) % (2**32))
+        return rng.standard_normal(self.dim)
+
+    def encode(
+        self,
+        zone_overlay: List[List[Optional[str]]],
+        entropy_mask: Optional[List[List[float]]] | None = None,
+        symbolic_overlay: Optional[List[List[Optional[str]]]] | None = None,
+    ) -> np.ndarray:
+        """Return deterministic embedding of task structure."""
+
+        vec = np.zeros(self.dim, dtype=float)
+        height = len(zone_overlay)
+        width = len(zone_overlay[0]) if height > 0 else 0
+        for r in range(height):
+            for c in range(width):
+                label = zone_overlay[r][c]
+                if label is not None:
+                    vec += self._embed_token(str(label))
+                if symbolic_overlay is not None:
+                    sym = symbolic_overlay[r][c]
+                    if sym is not None:
+                        vec += self._embed_token(str(sym))
+                if entropy_mask is not None:
+                    vec += float(entropy_mask[r][c])
+        norm = np.linalg.norm(vec)
+        if norm > 0:
+            vec /= norm
+        return vec
+
+
+__all__ = ["StructuralEncoder"]

--- a/arc_solver/src/attention/symbolic_attention.py
+++ b/arc_solver/src/attention/symbolic_attention.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Rule ranking attention mechanism."""
+
+from typing import List, Tuple
+
+import numpy as np
+
+from arc_solver.src.symbolic.rule_language import rule_to_dsl
+
+
+class SymbolicAttention:
+    """Apply structural context to rule ranking."""
+
+    def __init__(self, weight: float = 0.2, dim: int = 32) -> None:
+        self.weight = weight
+        self.dim = dim
+
+    def _embed_token(self, token: str) -> np.ndarray:
+        rng = np.random.default_rng(abs(hash(token)) % (2**32))
+        return rng.standard_normal(self.dim)
+
+    def _embed_rule(self, rules: List) -> np.ndarray:
+        if not rules:
+            return np.zeros(self.dim, dtype=float)
+        vec = np.zeros(self.dim, dtype=float)
+        for r in rules:
+            vec += self._embed_token(rule_to_dsl(r))
+        vec /= len(rules)
+        return vec
+
+    def apply(
+        self, ranked_rules: List[Tuple[List, float]], context_vec: np.ndarray
+    ) -> List[Tuple[List, float]]:
+        """Return reranked rule sets with attention-adjusted scores."""
+
+        adjusted: List[Tuple[List, float]] = []
+        for rules, base in ranked_rules:
+            rule_vec = self._embed_rule(rules)
+            score = float(np.dot(rule_vec, context_vec))
+            adjusted.append((rules, base + self.weight * score))
+        adjusted.sort(key=lambda x: x[1], reverse=True)
+        return adjusted
+
+
+__all__ = ["SymbolicAttention"]

--- a/arc_solver/src/evaluation/ablation.py
+++ b/arc_solver/src/evaluation/ablation.py
@@ -1,0 +1,26 @@
+"""Utilities for ablation testing of structural attention."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from arc_solver.src.executor.full_pipeline import solve_task
+from arc_solver.src.utils import config_loader
+from arc_solver.src.evaluation.metrics import task_score
+
+
+def compare_attention(task: dict) -> Tuple[float, float]:
+    """Return task scores with and without structural attention."""
+
+    config_loader.set_use_structural_attention(False)
+    preds_no, targets, _, _ = solve_task(task)
+    score_no = task_score(preds_no, targets)
+
+    config_loader.set_use_structural_attention(True)
+    preds_yes, targets, _, _ = solve_task(task)
+    score_yes = task_score(preds_yes, targets)
+
+    return score_no, score_yes
+
+
+__all__ = ["compare_attention"]

--- a/arc_solver/src/executor/full_pipeline.py
+++ b/arc_solver/src/executor/full_pipeline.py
@@ -13,6 +13,7 @@ from arc_solver.src.executor.attention import AttentionMask, zone_to_mask
 from arc_solver.src.executor.dependency import select_independent_rules
 from arc_solver.src.segment.segmenter import zone_overlay
 from arc_solver.src.rank_rule_sets import probabilistic_rank_rule_sets
+from arc_solver.src.attention.fusion_injector import apply_structural_attention
 from arc_solver.src.memory.memory_store import (
     load_memory,
     retrieve_similar_signatures,
@@ -141,6 +142,12 @@ def solve_task(
             rule_sets.append(select_independent_rules(p))
 
     ranked_rules = probabilistic_rank_rule_sets(rule_sets, train_pairs)
+    if config_loader.META_CONFIG.get("use_structural_attention") and train_pairs:
+        ranked_rules = apply_structural_attention(
+            train_pairs[0][0],
+            ranked_rules,
+            config_loader.META_CONFIG.get("structural_attention_weight", 0.2),
+        )
     best_rules: List = ranked_rules[0][0] if ranked_rules else []
 
     # Recall programs from memory or priors ---------------------------------

--- a/arc_solver/src/utils/config_loader.py
+++ b/arc_solver/src/utils/config_loader.py
@@ -45,6 +45,9 @@ PRIOR_FROM_MEMORY: bool = bool(_PRIOR_CONF.get("inject_from_memory", False))
 PRIOR_FALLBACK_ONLY: bool = bool(_PRIOR_CONF.get("fallback_only", False))
 PRIOR_MAX_INJECT: int = int(_PRIOR_CONF.get("max_inject", 3))
 
+USE_STRUCTURAL_ATTENTION: bool = bool(META_CONFIG.get("use_structural_attention", False))
+STRUCTURAL_ATTENTION_WEIGHT: float = float(META_CONFIG.get("structural_attention_weight", 0.2))
+
 
 def set_offline_mode(value: bool) -> None:
     """Override offline mode at runtime."""
@@ -86,3 +89,15 @@ def set_prior_threshold(value: int) -> None:
     """Override number of max injected priors."""
     global PRIOR_MAX_INJECT
     PRIOR_MAX_INJECT = value
+
+
+def set_use_structural_attention(value: bool) -> None:
+    """Enable or disable structural attention."""
+    global USE_STRUCTURAL_ATTENTION
+    USE_STRUCTURAL_ATTENTION = value
+
+
+def set_attention_weight(value: float) -> None:
+    """Override structural attention weight."""
+    global STRUCTURAL_ATTENTION_WEIGHT
+    STRUCTURAL_ATTENTION_WEIGHT = value

--- a/arc_solver/tests/test_pipeline_with_attention.py
+++ b/arc_solver/tests/test_pipeline_with_attention.py
@@ -1,0 +1,12 @@
+import json
+from pathlib import Path
+
+from arc_solver.src.executor.full_pipeline import solve_task
+from arc_solver.src.utils import config_loader
+
+
+def test_pipeline_runs_with_attention():
+    config_loader.set_use_structural_attention(True)
+    task = json.loads(Path("arc_solver/tests/sample_task.json").read_text())
+    preds, _, _, _ = solve_task(task)
+    assert preds and preds[0].shape() == (1, 1)

--- a/arc_solver/tests/test_structural_encoder.py
+++ b/arc_solver/tests/test_structural_encoder.py
@@ -1,0 +1,11 @@
+import numpy as np
+from arc_solver.src.attention.structural_encoder import StructuralEncoder
+
+
+def test_encoding_deterministic():
+    encoder = StructuralEncoder(dim=8)
+    overlay = [["A", None], [None, "B"]]
+    vec1 = encoder.encode(overlay)
+    vec2 = encoder.encode(overlay)
+    assert vec1.shape == (8,)
+    assert np.allclose(vec1, vec2)

--- a/arc_solver/tests/test_symbolic_attention.py
+++ b/arc_solver/tests/test_symbolic_attention.py
@@ -1,0 +1,14 @@
+import numpy as np
+from arc_solver.src.attention.symbolic_attention import SymbolicAttention
+from arc_solver.src.symbolic.rule_language import parse_rule
+
+
+def test_attention_reranks():
+    attn = SymbolicAttention(weight=1.0, dim=8)
+    rule_a = [parse_rule("REPLACE [COLOR=0] -> [COLOR=1]")]
+    rule_b = [parse_rule("TRANSLATE [COLOR=0] -> [COLOR=0]")]
+    context = attn._embed_rule(rule_a)
+    ranked = [(rule_b, 0.5), (rule_a, 0.5)]
+    out = attn.apply(ranked, context)
+    assert out[0][0] == rule_a
+    assert out[0][1] > out[1][1]


### PR DESCRIPTION
## Summary
- implement structural encoder and symbolic attention modules
- integrate attention scores during rule ranking
- expose configuration toggles and CLI flags
- add ablation utility and new color histogram features
- test structural encoder, symbolic attention, and pipeline

## Testing
- `pip install -e .` (setup)
- `pip install numpy pyyaml matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410d1d01b48322a80c8cfc95ae3c56