### PR TITLE
Connect CLI flags to structural attention

### DIFF
--- a/arc_solver/src/executor/full_pipeline.py
+++ b/arc_solver/src/executor/full_pipeline.py
@@ -142,11 +142,11 @@ def solve_task(
             rule_sets.append(select_independent_rules(p))
 
     ranked_rules = probabilistic_rank_rule_sets(rule_sets, train_pairs)
-    if config_loader.META_CONFIG.get("use_structural_attention") and train_pairs:
+    if config_loader.USE_STRUCTURAL_ATTENTION and train_pairs:
         ranked_rules = apply_structural_attention(
             train_pairs[0][0],
             ranked_rules,
-            config_loader.META_CONFIG.get("structural_attention_weight", 0.2),
+            config_loader.STRUCTURAL_ATTENTION_WEIGHT,
         )
     best_rules: List = ranked_rules[0][0] if ranked_rules else []
 

--- a/arc_solver/tests/test_run_agi_solver.py
+++ b/arc_solver/tests/test_run_agi_solver.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import sys
 import json
 from arc_solver.scripts.run_agi_solver import main
+from arc_solver.src.utils import config_loader
 
 
 def test_run_agi_solver_creates_submission(tmp_path, monkeypatch):
@@ -26,4 +27,30 @@ def test_run_agi_solver_creates_submission(tmp_path, monkeypatch):
     data = json.loads(out_file.read_text())
     assert "00000001" in data
     assert data["00000001"]["output"] == [[[[1]], [[1]]]]
+
+
+def test_cli_flag_toggles_attention(tmp_path, monkeypatch):
+    data_dir = tmp_path
+    out_file = tmp_path / "submission.json"
+    src = Path(__file__).with_name("sample_agi-challenges.json")
+    (data_dir / "arc-agi_training_challenges.json").write_text(src.read_text())
+
+    argv = [
+        "prog",
+        "--split",
+        "train",
+        "--data_dir",
+        str(data_dir),
+        "--output",
+        str(out_file),
+        "--use_structural_attention",
+        "--attention_weight",
+        "0.3",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    config_loader.set_use_structural_attention(False)
+    config_loader.set_attention_weight(0.1)
+    main()
+    assert config_loader.USE_STRUCTURAL_ATTENTION is True
+    assert config_loader.STRUCTURAL_ATTENTION_WEIGHT == 0.3
 


### PR DESCRIPTION
## Summary
- make pipeline reference structural attention globals
- verify CLI toggles structural attention runtime settings

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410fe230b88322a45bcae0ff0821f4