### PR TITLE
Robustness fixes across solver

### DIFF
--- a/arc_solver/src/core/grid.py
+++ b/arc_solver/src/core/grid.py
@@ -21,11 +21,17 @@ class Grid:
             if len(row) != row_len:
                 raise ValueError("All rows must have the same length")
 
-    def get(self, row: int, col: int) -> int:
-        """Return the color value at the specified cell with bounds checking."""
-        if 0 <= row < len(self.data) and 0 <= col < len(self.data[0]):
-            return self.data[row][col]
-        return None
+    def get(self, row: int, col: int, default: Any | None = None) -> Any:
+        """Return the color value at ``row``, ``col`` or ``default`` if out of bounds."""
+        if row < 0 or col < 0:
+            return default
+        if row >= len(self.data):
+            return default
+        if not self.data or col >= len(self.data[0]):
+            return default
+        if col >= len(self.data[row]):  # defensive for malformed rows
+            return default
+        return self.data[row][col]
 
     def set(self, row: int, col: int, value: int) -> None:
         """Set the color value at the specified cell."""

--- a/arc_solver/src/executor/fallback_predictor.py
+++ b/arc_solver/src/executor/fallback_predictor.py
@@ -1,6 +1,27 @@
-"""Fallback predictor for unseen tasks."""
+"""Fallback predictor for unseen tasks.
+
+This simple policy either returns the input grid unchanged or pads it to a
+square using the most frequent color. It is intended to keep the pipeline
+alive when upstream rule synthesis fails.
+"""
 
 
-def predict(grid):
-    """Return a best guess solution."""
-    return grid
+from arc_solver.src.core.grid import Grid
+
+
+def predict(grid: Grid) -> Grid:
+    """Return a naive guess for the output grid."""
+
+    try:
+        h, w = grid.shape()
+    except Exception:
+        return grid
+
+    counts = grid.count_colors()
+    mode = max(counts, key=counts.get) if counts else 0
+    size = max(h, w)
+    new_data = [[mode for _ in range(size)] for _ in range(size)]
+    for r in range(h):
+        for c in range(w):
+            new_data[r][c] = grid.get(r, c)
+    return Grid(new_data)

--- a/arc_solver/src/introspection/trace_builder.py
+++ b/arc_solver/src/introspection/trace_builder.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from arc_solver.src.core.grid import Grid
 from arc_solver.src.symbolic.vocabulary import Symbol, SymbolType, SymbolicRule
 from arc_solver.src.segment.segmenter import zone_overlay
+import logging
 
 
 @dataclass
@@ -32,6 +33,7 @@ def build_trace(
 ) -> RuleTrace:
     """Return a :class:`RuleTrace` describing ``rule``'s effect."""
 
+    logger = logging.getLogger("trace_builder")
     height, width = grid_in.shape()
 
     affected: List[Tuple[int, int]] = []
@@ -39,6 +41,7 @@ def build_trace(
         for c in range(width):
             if grid_in.get(r, c) != grid_out.get(r, c):
                 affected.append((r, c))
+                logger.debug("cell %d,%d changed from %s to %s", r, c, grid_in.get(r, c), grid_out.get(r, c))
 
     if grid_true is not None and grid_true.shape() == grid_out.shape():
         delta_mask = [
@@ -72,6 +75,7 @@ def build_trace(
                     zones.add(s.value)
                 elif s.type is SymbolType.REGION:
                     regions.add(s.value)
+            logger.debug("trace cell %d,%d labels=%s", r, c, [str(s) for s in syms])
         if zones:
             context["zones"] = sorted(zones)
         if regions:

--- a/arc_solver/src/symbolic/rule_language.py
+++ b/arc_solver/src/symbolic/rule_language.py
@@ -15,6 +15,8 @@ from .vocabulary import (
 
 
 def _parse_symbol(token: str) -> Symbol:
+    if "=" not in token:
+        raise ValueError(f"Invalid symbol token: {token}")
     key, value = token.split("=", 1)
     key = key.strip().upper()
     value = value.strip()

--- a/arc_solver/tests/test_full_pipeline_fallback.py
+++ b/arc_solver/tests/test_full_pipeline_fallback.py
@@ -1,0 +1,8 @@
+from arc_solver.src.executor.full_pipeline import solve_task
+from arc_solver.src.core.grid import Grid
+
+
+def test_pipeline_empty_rules():
+    task = {"train": [], "test": [{"input": [[1]]}]}
+    preds, outs, traces, rules = solve_task(task)
+    assert preds and isinstance(preds[0], Grid)

--- a/arc_solver/tests/test_regime_classifier.py
+++ b/arc_solver/tests/test_regime_classifier.py
@@ -25,3 +25,17 @@ def test_delta_requires_heuristic():
     out = Grid([[i + j + 2 for j in range(5)] for i in range(5)])
     sig = compute_task_signature([(inp, out)])
     assert predict_regime_category(sig) is RegimeType.RequiresHeuristic
+
+
+def test_misaligned_pair_no_crash():
+    inp = Grid([[1, 1], [1, 1]])
+    out = Grid([[1]])
+    sig = compute_task_signature([(inp, out)])
+    assert isinstance(sig, dict)
+
+
+def test_corrupted_task_zero_width():
+    inp = Grid([[]])
+    out = Grid([[]])
+    sig = compute_task_signature([(inp, out)])
+    assert isinstance(sig, dict)

--- a/arc_solver/tests/test_rule_executor.py
+++ b/arc_solver/tests/test_rule_executor.py
@@ -1,0 +1,23 @@
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.executor.simulator import simulate_rules
+from arc_solver.src.symbolic.vocabulary import Symbol, SymbolType, SymbolicRule, Transformation, TransformationType, TransformationNature
+from arc_solver.src.symbolic.rule_language import parse_rule
+import pytest
+
+
+def test_apply_replace_invalid_symbol():
+    grid = Grid([[4, 4], [4, 4]])
+    rule = SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "4|LOGICAL")],
+        target=[Symbol(SymbolType.COLOR, "2")],
+        nature=TransformationNature.LOGICAL,
+    )
+    out = simulate_rules(grid, [rule])
+    assert out.data == grid.data
+
+
+def test_parse_rule_invalid_token():
+    rule = parse_rule("REPLACE [COLOR=4|LOGICAL] -> [COLOR=1]")
+    out = simulate_rules(Grid([[4]]), [rule])
+    assert out.data == [[4]]


### PR DESCRIPTION
## Summary
- guard grid access and handle malformed pairs in `compute_task_signature`
- add validation logging for traces and regimes
- make fallback predictor pad grids for safety
- allow solver pipeline to fall back when rule extraction fails
- sanitize submission grids and rule application
- expose trace logging via CLI
- add regression tests for regime classifier and rule executor

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841173ddbc8832284f801ae996f583e