### PR TITLE
Implement validation and fallback patches

### DIFF
--- a/arc_solver/scripts/run_agi_solver.py
+++ b/arc_solver/scripts/run_agi_solver.py
@@ -17,6 +17,8 @@ from typing import Dict, List, Tuple
 
 import matplotlib.pyplot as plt
 from arc_solver.src.data.visualization import visualize
+from arc_solver.src.utils import config_loader
+from arc_solver.src.utils.logger import get_logger
 
 from arc_solver.src.core.grid import Grid
 
@@ -266,6 +268,9 @@ def main() -> None:
 
     preload_memory_from_kaggle_input()
     config_sanity_check(args)
+    logger = get_logger("run_agi_solver")
+    config_loader.print_runtime_config()
+    logger.info(f"Using config: {config_loader.META_CONFIG}")
 
     split_prefix = {
         "train": "arc-agi_training",

--- a/arc_solver/src/attention/fusion_injector.py
+++ b/arc_solver/src/attention/fusion_injector.py
@@ -20,7 +20,9 @@ def apply_structural_attention(
 
     overlay = zone_overlay(grid)
     encoder = StructuralEncoder(dim=_DEF_DIM)
-    context = encoder.encode([[z.value if z else None for z in row] for row in overlay])
+    context = encoder.encode(
+        grid, [[z.value if z else None for z in row] for row in overlay]
+    )
     attention = SymbolicAttention(weight=weight, dim=_DEF_DIM)
     return attention.apply(ranked_rules, context)
 

--- a/arc_solver/src/attention/structural_encoder.py
+++ b/arc_solver/src/attention/structural_encoder.py
@@ -2,12 +2,21 @@ from __future__ import annotations
 
 """Simple structural context encoder for ARC grids."""
 
-from typing import List, Optional
+from typing import Any, List, Optional
+
+from arc_solver.src.core.grid import Grid
 
 
-def validate_overlay(overlay: List) -> bool:
-    """Return True if ``overlay`` is a 2D list."""
-    return isinstance(overlay, list) and all(isinstance(row, list) for row in overlay)
+def validate_overlay(grid: Grid, overlay: List[List[Any]]) -> bool:
+    """Return True if ``overlay`` matches ``grid`` and has valid values."""
+    h, w = grid.shape()
+    if len(overlay) != h or any(len(row) != w for row in overlay):
+        return False
+    for row in overlay:
+        for val in row:
+            if val is not None and not isinstance(val, (str, int)):
+                return False
+    return True
 
 import numpy as np
 
@@ -24,13 +33,14 @@ class StructuralEncoder:
 
     def encode(
         self,
+        grid: Grid,
         zone_overlay: List[List[Optional[str]]],
         entropy_mask: Optional[List[List[float]]] | None = None,
         symbolic_overlay: Optional[List[List[Optional[str]]]] | None = None,
     ) -> np.ndarray:
         """Return deterministic embedding of task structure."""
 
-        if not validate_overlay(zone_overlay):
+        if not validate_overlay(grid, zone_overlay):
             raise ValueError("Invalid overlay structure")
 
         vec = np.zeros(self.dim, dtype=float)
@@ -53,4 +63,4 @@ class StructuralEncoder:
         return vec
 
 
-__all__ = ["StructuralEncoder"]
+__all__ = ["StructuralEncoder", "validate_overlay"]

--- a/arc_solver/src/executor/fallback_predictor.py
+++ b/arc_solver/src/executor/fallback_predictor.py
@@ -9,6 +9,17 @@ alive when upstream rule synthesis fails.
 from arc_solver.src.core.grid import Grid
 
 
+def pad_to_expected(grid: Grid, fill: int) -> Grid:
+    """Return ``grid`` padded to square shape filled with ``fill``."""
+    h, w = grid.shape()
+    size = max(h, w)
+    new_data = [[fill for _ in range(size)] for _ in range(size)]
+    for r in range(h):
+        for c in range(w):
+            new_data[r][c] = grid.get(r, c)
+    return Grid(new_data)
+
+
 def predict(grid: Grid) -> Grid:
     """Return a naive guess for the output grid."""
 
@@ -19,9 +30,4 @@ def predict(grid: Grid) -> Grid:
 
     counts = grid.count_colors()
     mode = max(counts, key=counts.get) if counts else 0
-    size = max(h, w)
-    new_data = [[mode for _ in range(size)] for _ in range(size)]
-    for r in range(h):
-        for c in range(w):
-            new_data[r][c] = grid.get(r, c)
-    return Grid(new_data)
+    return pad_to_expected(grid, fill=mode)

--- a/arc_solver/src/executor/simulator.py
+++ b/arc_solver/src/executor/simulator.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 import logging
 
 from arc_solver.src.utils.logger import get_logger
+from arc_solver.src.symbolic.vocabulary import validate_color_range, MAX_COLOR
 
 from arc_solver.src.core.grid import Grid
 from arc_solver.src.symbolic.vocabulary import (
@@ -86,6 +87,8 @@ def _apply_replace(
                 return grid
             break
     if src_color is None or tgt_color is None:
+        return grid
+    if not validate_color_range(tgt_color):
         return grid
 
     h, w = grid.shape()

--- a/arc_solver/src/memory/memory_store.py
+++ b/arc_solver/src/memory/memory_store.py
@@ -59,8 +59,18 @@ def retrieve_similar_signatures(
     scored.sort(key=lambda x: x[0], reverse=True)
     results: List[Dict[str, Any]] = []
     for sim, entry in scored[:top_k]:
-        rules = [parse_rule(r) for r in entry.get("rules", [])]
-        results.append({"rules": rules, "score": entry.get("score", 0.0), "similarity": sim})
+        parsed = []
+        for r in entry.get("rules", []):
+            try:
+                rule = parse_rule(r)
+            except Exception:
+                continue
+            if not rule.is_well_formed():
+                continue
+            parsed.append(rule)
+        if not parsed:
+            continue
+        results.append({"rules": parsed, "score": entry.get("score", 0.0), "similarity": sim})
     return results
 
 

--- a/arc_solver/src/symbolic/rule_language.py
+++ b/arc_solver/src/symbolic/rule_language.py
@@ -11,6 +11,7 @@ from .vocabulary import (
     Transformation,
     TransformationNature,
     TransformationType,
+    validate_color_range,
 )
 
 
@@ -24,6 +25,8 @@ def _parse_symbol(token: str) -> Symbol:
         stype = SymbolType[key]
     except KeyError as exc:
         raise ValueError(f"Unknown symbol type: {key}") from exc
+    if stype is SymbolType.COLOR and not validate_color_range(value):
+        raise ValueError(f"Invalid color value: {value}")
     return Symbol(stype, value)
 
 

--- a/arc_solver/src/symbolic/vocabulary.py
+++ b/arc_solver/src/symbolic/vocabulary.py
@@ -4,7 +4,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, List
+from typing import Any, Dict, List
+
+MAX_COLOR = 10
+
+
+def validate_color_range(value: int) -> bool:
+    """Return True if ``value`` represents a legal color index."""
+    try:
+        iv = int(value)
+        return 0 <= iv < MAX_COLOR
+    except Exception:
+        # Allow non-integer color tokens (e.g. "Red")
+        return True
 
 
 class SymbolType(Enum):
@@ -57,6 +69,17 @@ class Symbol:
 
     type: SymbolType
     value: str
+
+    def __post_init__(self) -> None:
+        if self.type is SymbolType.COLOR:
+            if not validate_color_range(self.value):
+                raise ValueError(f"Invalid symbol value: {self.value}")
+
+    def is_valid(self) -> bool:
+        """Return ``True`` if this symbol represents a valid token."""
+        if self.type is SymbolType.COLOR:
+            return validate_color_range(self.value)
+        return True
 
     def __str__(self) -> str:
         return f"{self.type.value}={self.value}"
@@ -111,9 +134,9 @@ class SymbolicRule:
         """Return True if color tokens contain valid integer values."""
         try:
             for sym in self.source + self.target:
-                if sym.type is SymbolType.COLOR:
-                    int(sym.value)
-        except ValueError:
+                if not sym.is_valid():
+                    return False
+        except Exception:
             return False
         return True
 
@@ -125,4 +148,6 @@ __all__ = [
     "Symbol",
     "Transformation",
     "SymbolicRule",
+    "validate_color_range",
+    "MAX_COLOR",
 ]

--- a/arc_solver/tests/test_fallback_predictor.py
+++ b/arc_solver/tests/test_fallback_predictor.py
@@ -1,0 +1,10 @@
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.executor import fallback_predictor
+
+
+def test_fallback_padding_shape():
+    g = Grid([[1, 2, 3], [4, 5, 6]])
+    out = fallback_predictor.predict(g)
+    assert out.shape() == (3, 3)
+    assert out.get(0, 0) == 1
+    assert out.get(2, 2) == 1

--- a/arc_solver/tests/test_invalid_rule_skip.py
+++ b/arc_solver/tests/test_invalid_rule_skip.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from arc_solver.src.memory.memory_store import retrieve_similar_signatures
+import json
+
+
+def test_invalid_rule_skipped(tmp_path):
+    mem_path = tmp_path / "mem.json"
+    data = [{
+        "task_id": "t1",
+        "signature": "sig",
+        "rules": ["REPLACE [COLOR=10] -> [COLOR=1]"]
+    }]
+    mem_path.write_text(json.dumps(data))
+    retrieved = retrieve_similar_signatures("sig", mem_path)
+    assert retrieved == []

--- a/arc_solver/tests/test_structural_encoder.py
+++ b/arc_solver/tests/test_structural_encoder.py
@@ -1,11 +1,13 @@
 import numpy as np
 from arc_solver.src.attention.structural_encoder import StructuralEncoder
+from arc_solver.src.core.grid import Grid
 
 
 def test_encoding_deterministic():
     encoder = StructuralEncoder(dim=8)
     overlay = [["A", None], [None, "B"]]
-    vec1 = encoder.encode(overlay)
-    vec2 = encoder.encode(overlay)
+    grid = Grid([[0, 0], [0, 0]])
+    vec1 = encoder.encode(grid, overlay)
+    vec2 = encoder.encode(grid, overlay)
     assert vec1.shape == (8,)
     assert np.allclose(vec1, vec2)

--- a/arc_solver/tests/test_structural_encoder_overlay_guard.py
+++ b/arc_solver/tests/test_structural_encoder_overlay_guard.py
@@ -1,0 +1,10 @@
+from arc_solver.src.attention.structural_encoder import validate_overlay
+from arc_solver.src.core.grid import Grid
+
+
+def test_validate_overlay_shape_and_type():
+    grid = Grid([[0, 0], [0, 0]])
+    bad_overlay = [[None], [None]]
+    assert not validate_overlay(grid, bad_overlay)
+    good_overlay = [[None, 1], ["A", None]]
+    assert validate_overlay(grid, good_overlay)

--- a/arc_solver/tests/test_symbol_validation.py
+++ b/arc_solver/tests/test_symbol_validation.py
@@ -1,0 +1,13 @@
+import pytest
+from arc_solver.src.symbolic.rule_language import parse_rule
+from arc_solver.src.symbolic.vocabulary import Symbol
+
+
+def test_parse_rule_valid_colors():
+    rule = parse_rule("REPLACE [COLOR=1] -> [COLOR=2]")
+    assert all(sym.is_valid() for sym in rule.source + rule.target)
+
+
+def test_parse_rule_invalid_color():
+    with pytest.raises(ValueError):
+        parse_rule("REPLACE [COLOR=11] -> [COLOR=1]")


### PR DESCRIPTION
## Summary
- validate color tokens on parsing
- guard replace rules against invalid target colors
- add padding helper and enhanced fallback predictor
- ensure structural encoder overlay validity
- skip malformed rules when loading from memory
- improve pipeline robustness and logging
- expose runtime config in solver CLI
- add regression tests for new behaviours

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411d786e788322bc24ea3cc78ad94d