### PR TITLE
Harden DSL rule parsing

### DIFF
--- a/arc_solver/src/symbolic/abstraction_dsl.py
+++ b/arc_solver/src/symbolic/abstraction_dsl.py
@@ -3,9 +3,17 @@
 from __future__ import annotations
 
 from typing import List
+import logging
 
-from .rule_language import parse_rule, rule_to_dsl
+from .rule_language import (
+    parse_rule,
+    rule_to_dsl,
+    validate_dsl_program,
+    clean_dsl_string,
+)
 from .vocabulary import SymbolicRule
+
+logger = logging.getLogger(__name__)
 
 
 def rules_to_program(rules: List[SymbolicRule]) -> str:
@@ -17,7 +25,20 @@ def program_to_rules(text: str) -> List[SymbolicRule]:
     """Parse a program string back into rules."""
     if not text.strip():
         return []
-    return [parse_rule(part.strip()) for part in text.split("|") if part.strip()]
+    rules: List[SymbolicRule] = []
+    for part in text.split("|"):
+        raw = part.strip()
+        if not raw:
+            continue
+        cleaned = clean_dsl_string(raw)
+        if not validate_dsl_program(cleaned):
+            logger.warning(f"Skipping malformed rule: {raw}")
+            continue
+        try:
+            rules.append(parse_rule(cleaned))
+        except Exception as exc:  # noqa: PERF203 - defensive parse
+            logger.warning(f"Skipping invalid rule: {raw} ({exc})")
+    return rules
 
 
 __all__ = ["rules_to_program", "program_to_rules"]

--- a/arc_solver/src/symbolic/rule_language.py
+++ b/arc_solver/src/symbolic/rule_language.py
@@ -1,8 +1,15 @@
-"""Parsing utilities for the symbolic rule DSL."""
+"""Parsing utilities for the symbolic rule DSL.
+
+This module now performs basic validation and sanitisation of DSL
+expressions to avoid malformed rules crashing the solver.  It exposes
+helpers used by :mod:`abstraction_dsl` for round trip checking and
+program parsing.
+"""
 
 from __future__ import annotations
 
 from typing import List
+import logging
 
 from .vocabulary import (
     Symbol,
@@ -13,6 +20,51 @@ from .vocabulary import (
     TransformationType,
     validate_color_range,
 )
+
+logger = logging.getLogger(__name__)
+
+DSL_GRAMMAR = {
+    "type": [t.name.lower() for t in TransformationType],
+    "symbol_range": range(0, 10),
+    "operators": ["->", "|", "&"],
+    "fields": ["color", "zone", "transform", "position"],
+}
+
+MAX_SYMBOL_VALUE = 10
+
+
+def clean_dsl_string(s: str) -> str:
+    """Return ``s`` trimmed of surrounding and newline whitespace."""
+
+    return s.strip().replace("\n", "").replace("\t", "")
+
+
+def validate_dsl_program(program_str: str) -> bool:
+    """Return ``True`` if ``program_str`` looks like a well formed DSL rule."""
+
+    if not isinstance(program_str, str):
+        return False
+    if "->" not in program_str:
+        return False
+    if program_str.count("[") != program_str.count("]"):
+        return False
+    if any(tok in program_str for tok in ["NaN", "None"]):
+        return False
+    op = clean_dsl_string(program_str).split("[", 1)[0].strip()
+    if op.upper() not in {t.name for t in TransformationType}:
+        return False
+    return True
+
+
+def extract_symbol_value(s: str) -> int:
+    """Parse ``s`` as an integer within ``MAX_SYMBOL_VALUE``."""
+
+    try:
+        val = int(s)
+        assert 0 <= val < MAX_SYMBOL_VALUE
+        return val
+    except Exception as exc:  # noqa: PERF203 - simple guard
+        raise ValueError(f"Invalid symbol value in: {s}") from exc
 
 
 def _parse_symbol(token: str) -> Symbol:
@@ -25,8 +77,11 @@ def _parse_symbol(token: str) -> Symbol:
         stype = SymbolType[key]
     except KeyError as exc:
         raise ValueError(f"Unknown symbol type: {key}") from exc
-    if stype is SymbolType.COLOR and not validate_color_range(value):
-        raise ValueError(f"Invalid color value: {value}")
+    if stype is SymbolType.COLOR:
+        value_int = extract_symbol_value(value)
+        if not validate_color_range(value_int):
+            raise ValueError(f"Invalid color value: {value}")
+        value = str(value_int)
     return Symbol(stype, value)
 
 
@@ -41,7 +96,9 @@ def _parse_symbol_list(text: str) -> List[Symbol]:
 
 
 def parse_rule(text: str) -> SymbolicRule:
-    text = text.strip()
+    text = clean_dsl_string(text)
+    if not validate_dsl_program(text):
+        raise ValueError("Malformed rule expression")
     if " " not in text:
         raise ValueError("Invalid rule format")
     op, remainder = text.split(" ", 1)
@@ -62,4 +119,9 @@ def rule_to_dsl(rule: SymbolicRule) -> str:
     return str(rule)
 
 
-__all__ = ["parse_rule", "rule_to_dsl"]
+__all__ = [
+    "parse_rule",
+    "rule_to_dsl",
+    "validate_dsl_program",
+    "clean_dsl_string",
+]

--- a/arc_solver/tests/test_rule_language.py
+++ b/arc_solver/tests/test_rule_language.py
@@ -1,0 +1,33 @@
+import pytest
+
+from arc_solver.src.symbolic.rule_language import (
+    parse_rule,
+    rule_to_dsl,
+    validate_dsl_program,
+    clean_dsl_string,
+)
+from arc_solver.src.symbolic.vocabulary import SymbolicRule
+
+
+def test_parse_valid_rule():
+    rule = parse_rule("REPLACE [COLOR=1] -> [COLOR=2]")
+    assert isinstance(rule, SymbolicRule)
+
+
+def test_parse_invalid_symbol():
+    with pytest.raises(ValueError):
+        parse_rule("REPLACE [COLOR=11] -> [COLOR=1]")
+
+
+def test_roundtrip_consistency():
+    rule = parse_rule("REPLACE [COLOR=3] -> [COLOR=4]")
+    stringified = rule_to_dsl(rule)
+    parsed = parse_rule(stringified)
+    assert parsed == rule
+
+
+def test_edge_tokens():
+    assert not validate_dsl_program("NaN")
+    assert not validate_dsl_program("None")
+    with pytest.raises(ValueError):
+        parse_rule(clean_dsl_string("FOO [COLOR=1]->[COLOR=2]"))


### PR DESCRIPTION
## Summary
- add schema and value guards in `rule_language`
- sanitize input before parsing in `abstraction_dsl`
- add unit tests for parser edge cases

## Testing
- `PYTHONPATH=. pytest arc_solver/tests/test_rule_language.py -q`
- `PYTHONPATH=. pytest -q` *(fails: 21 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684139c5f2388322a021447b26f58a73