### PR TITLE
Update config defaults for recent patches

### DIFF
--- a/arc_solver/configs/meta_config.yaml
+++ b/arc_solver/configs/meta_config.yaml
@@ -17,6 +17,10 @@ use_memory: false
 use_structural_attention: true
 structural_attention_weight: 0.2
 lazy_memory: false
+memory_similarity_threshold: 0.95
+memory_diagnostics: false
+sparse_mode: false
+fallback_on_abstraction_fail: false
 regime_thresholds:
   entropy_low: 0.1
   zone_alignment_cutoff: 0.3

--- a/arc_solver/scripts/run_agi_solver.py
+++ b/arc_solver/scripts/run_agi_solver.py
@@ -207,6 +207,13 @@ def config_sanity_check(args: argparse.Namespace) -> None:
     config_loader.set_fallback_on_abstraction_fail(args.fallback_on_abstraction_fail)
     config_loader.set_introspection_enabled(args.introspect)
     config_loader.set_memory_enabled(args.use_memory)
+    # Define memory subsystem defaults for compatibility
+    config_loader.MEMORY_SIMILARITY_THRESHOLD = config_loader.META_CONFIG.get(
+        "memory_similarity_threshold", 0.95
+    )
+    config_loader.MEMORY_DIAGNOSTICS = config_loader.META_CONFIG.get(
+        "memory_diagnostics", False
+    )
     config_loader.print_runtime_config()
 
 


### PR DESCRIPTION
## Summary
- add missing compatibility fields to `meta_config.yaml`
- inject memory subsystem defaults in `run_agi_solver`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68413e4102a883229967ee48bb724a39