### PR TITLE
Bugfix: load memory constants

### DIFF
--- a/arc_solver/src/utils/config_loader.py
+++ b/arc_solver/src/utils/config_loader.py
@@ -51,6 +51,14 @@ STRUCTURAL_ATTENTION_WEIGHT: float = float(META_CONFIG.get("structural_attention
 INTROSPECTION_ENABLED: bool = bool(META_CONFIG.get("introspect", False))
 MEMORY_ENABLED: bool = bool(META_CONFIG.get("use_memory", False))
 LAZY_MEMORY_LOADING: bool = bool(META_CONFIG.get("lazy_memory", False))
+MEMORY_SIMILARITY_THRESHOLD: float = float(
+    META_CONFIG.get("memory_similarity_threshold", 0.95)
+)
+MEMORY_DIAGNOSTICS: bool = bool(META_CONFIG.get("memory_diagnostics", False))
+SPARSE_MODE: bool = bool(META_CONFIG.get("sparse_mode", False))
+FALLBACK_ON_ABSTRACTION_FAIL: bool = bool(
+    META_CONFIG.get("fallback_on_abstraction_fail", False)
+)
 
 
 


### PR DESCRIPTION
## Summary
- include missing config constants for memory and fallback features

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest arc_solver/tests/test_grid_validation.py -q`
- `pytest arc_solver/tests/test_memory_store.py::test_memory_save_and_retrieve -q`
- `pytest arc_solver/tests/test_abstraction.py::test_generalize_rules_deduplicates -q`
- `pytest arc_solver/tests/test_invalid_rule_skip.py::test_invalid_rule_skipped -q`
- `pytest -q` *(fails: 4 failed, 90 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684140e3af5c83228e3a9eae70a8a8e9