### PR TITLE
Improve memory recall diagnostics

### DIFF
--- a/arc_solver/configs/meta_config.yaml
+++ b/arc_solver/configs/meta_config.yaml
@@ -10,15 +10,16 @@ reflex_override:
 prior_injection:
   enabled: true
   use_motifs: true
-  inject_from_memory: true
+  inject_from_memory: false
   fallback_only: false
 introspect: false
 use_memory: false
 use_structural_attention: true
 structural_attention_weight: 0.2
 lazy_memory: false
-memory_similarity_threshold: 0.95
-memory_diagnostics: false
+memory_similarity_threshold: 0.80
+memory_diagnostics: true
+ignore_memory_shape_constraint: true
 sparse_mode: false
 fallback_on_abstraction_fail: false
 regime_thresholds:

--- a/arc_solver/src/symbolic/rule_language.py
+++ b/arc_solver/src/symbolic/rule_language.py
@@ -18,6 +18,7 @@ from .vocabulary import (
     Transformation,
     TransformationNature,
     TransformationType,
+    validate_color_range as vocab_color_range,
 )
 
 logger = logging.getLogger(__name__)
@@ -35,15 +36,7 @@ MAX_SYMBOL_VALUE = 10
 def validate_color_range(color: int | str) -> bool:
     """Return ``True`` if ``color`` is a valid ARC color index (0-9)."""
 
-    try:
-        value = int(color)
-    except Exception:
-        logger.warning(f"Invalid color token: {color}")
-        return False
-    if 0 <= value < MAX_SYMBOL_VALUE:
-        return True
-    logger.warning(f"Color value out of range: {value}")
-    return False
+    return vocab_color_range(color)
 
 
 def clean_dsl_string(s: str) -> str:
@@ -91,10 +84,14 @@ def _parse_symbol(token: str) -> Symbol:
     except KeyError as exc:
         raise ValueError(f"Unknown symbol type: {key}") from exc
     if stype is SymbolType.COLOR:
-        value_int = extract_symbol_value(value)
-        if not validate_color_range(value_int):
-            raise ValueError(f"Invalid color value: {value}")
-        value = str(value_int)
+        if value.isdigit():
+            value_int = extract_symbol_value(value)
+            if not validate_color_range(value_int):
+                raise ValueError(f"Invalid color value: {value}")
+            value = str(value_int)
+        else:
+            if not validate_color_range(value):
+                raise ValueError(f"Invalid color value: {value}")
     return Symbol(stype, value)
 
 

--- a/arc_solver/src/utils/config_loader.py
+++ b/arc_solver/src/utils/config_loader.py
@@ -59,6 +59,9 @@ SPARSE_MODE: bool = bool(META_CONFIG.get("sparse_mode", False))
 FALLBACK_ON_ABSTRACTION_FAIL: bool = bool(
     META_CONFIG.get("fallback_on_abstraction_fail", False)
 )
+IGNORE_MEMORY_SHAPE_CONSTRAINT: bool = bool(
+    META_CONFIG.get("ignore_memory_shape_constraint", False)
+)
 
 
 
@@ -150,6 +153,13 @@ def set_fallback_on_abstraction_fail(value: bool) -> None:
     global FALLBACK_ON_ABSTRACTION_FAIL
     FALLBACK_ON_ABSTRACTION_FAIL = value
     META_CONFIG["fallback_on_abstraction_fail"] = value
+
+
+def set_ignore_memory_shape_constraint(value: bool) -> None:
+    """Enable or disable ignoring shape constraints during memory recall."""
+    global IGNORE_MEMORY_SHAPE_CONSTRAINT
+    IGNORE_MEMORY_SHAPE_CONSTRAINT = value
+    META_CONFIG["ignore_memory_shape_constraint"] = value
 
 
 def print_runtime_config() -> None:

--- a/arc_solver/tests/test_memory_store.py
+++ b/arc_solver/tests/test_memory_store.py
@@ -7,6 +7,7 @@ from arc_solver.src.memory.memory_store import (
     extract_task_constraints,
 )
 from arc_solver.src.symbolic.rule_language import parse_rule
+from arc_solver.src.utils import config_loader
 
 
 def test_memory_save_and_retrieve(tmp_path):
@@ -73,6 +74,28 @@ def test_injection_filter(tmp_path):
     }
     mem_path.write_text(json.dumps([entry]))
     constraints = {"shape": (3, 3)}
+    config_loader.set_ignore_memory_shape_constraint(False)
     matches = match_signature([1, 2, 3], mem_path, threshold=0.8, constraints=constraints)
     assert matches == []
+    config_loader.set_ignore_memory_shape_constraint(True)
+
+
+def test_recall_with_lower_threshold(tmp_path):
+    """Memory retrieval should succeed with similarity around 0.82."""
+    mem_path = tmp_path / "mem.json"
+    entry = {
+        "task_id": "t_sim",
+        "signature": [1.0, 0.0, 0.0],
+        "rules": ["REPLACE [COLOR=0] -> [COLOR=1]"],
+        "score": 0.9,
+    }
+    other = {
+        "task_id": "t_other",
+        "signature": [0.0, 1.0, 0.0],
+        "rules": ["REPLACE [COLOR=2] -> [COLOR=3]"],
+        "score": 0.4,
+    }
+    mem_path.write_text(json.dumps([entry, other]))
+    matches = match_signature([0.75, 0.5, 0.0], mem_path, threshold=0.8)
+    assert matches and matches[0]["task_id"] == "t_sim"
 

--- a/arc_solver/tests/test_policy_router_new.py
+++ b/arc_solver/tests/test_policy_router_new.py
@@ -1,9 +1,12 @@
 from arc_solver.src.regime.policy_router import decide_policy
 from arc_solver.src.regime.regime_classifier import RegimeType
+from arc_solver.src.utils import config_loader
 
 
 def test_policy_router_mapping():
+    config_loader.set_prior_injection(False)
     assert decide_policy(RegimeType.RequiresHeuristic, 0.2) == "fallback"
     assert decide_policy(RegimeType.LikelyConflicted, 0.3) == "repair_then_simulate"
     assert decide_policy(RegimeType.Fragmented, 0.2) == "fallback_then_prior"
     assert decide_policy(RegimeType.SymbolicallyTractable, 0.8) == "symbolic"
+    config_loader.set_prior_injection(True)


### PR DESCRIPTION
## Summary
- tweak meta configuration for memory recall
- add diagnostic logging and shape override to memory store
- support color names in DSL parser
- surface ignore-memory-shape toggle in config loader
- adjust memory-related tests

## Testing
- `PYTHONPATH=. pytest arc_solver/tests/test_memory_store.py -q`
- `PYTHONPATH=. pytest arc_solver/tests/test_policy_router_new.py arc_solver/tests/test_deep_prior.py::test_solve_task_with_priors arc_solver/tests/test_rule_executor.py::test_parse_rule_invalid_token arc_solver/tests/test_symbolic.py::test_parse_rule_basic -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684147f060e883229734b49385fdf891