### PR TITLE
Add local LLM self-repair

### DIFF
--- a/arc_solver/configs/meta_config.yaml
+++ b/arc_solver/configs/meta_config.yaml
@@ -1,6 +1,6 @@
 # Meta configuration for entire solver
 logging_level: INFO
-llm_mode: offline
+llm_mode: local
 repair_enabled: true
 repair_threshold: 0.7
 reflex_override:

--- a/arc_solver/scripts/run_agi_solver.py
+++ b/arc_solver/scripts/run_agi_solver.py
@@ -12,6 +12,7 @@ if str(repo_root) not in sys.path:
 import argparse
 import json
 import traceback
+import os
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -194,7 +195,7 @@ def config_sanity_check(args: argparse.Namespace) -> None:
     """Apply CLI options to global config and print the runtime settings."""
     from arc_solver.src.utils import config_loader
 
-    config_loader.set_offline_mode(args.llm_mode == "offline")
+    config_loader.set_llm_mode(args.llm_mode)
     config_loader.set_repair_enabled(args.allow_self_repair)
     config_loader.set_repair_threshold(args.repair_threshold)
     config_loader.set_reflex_override(args.regime_override)
@@ -266,9 +267,9 @@ def main() -> None:
     )
     parser.add_argument(
         "--llm_mode",
-        choices=["online", "offline"],
+        choices=["online", "offline", "local"],
         default="online",
-        help="Use local LLM when offline",
+        help="LLM usage mode",
     )
     parser.add_argument(
         "--allow_self_repair",
@@ -282,6 +283,12 @@ def main() -> None:
         help="Score threshold to trigger self-repair",
     )
     args = parser.parse_args()
+
+    if args.llm_mode == "local":
+        os.environ.setdefault(
+            "LOCAL_GGUF_MODEL_PATH",
+            "/kaggle/working/tinyllama-1.1b-chat-v1.0.q4_K_M.gguf",
+        )
 
     from arc_solver.src.memory import preload_memory_from_kaggle_input
 

--- a/arc_solver/src/utils/config_loader.py
+++ b/arc_solver/src/utils/config_loader.py
@@ -30,7 +30,8 @@ def load_meta_config(path: Optional[Path] = None) -> Dict[str, Any]:
 
 
 META_CONFIG: Dict[str, Any] = load_meta_config()
-OFFLINE_MODE: bool = META_CONFIG.get("llm_mode", "online") == "offline"
+LLM_MODE: str = str(META_CONFIG.get("llm_mode", "online"))
+OFFLINE_MODE: bool = LLM_MODE != "online"
 REPAIR_ENABLED: bool = META_CONFIG.get("repair_enabled", False)
 REPAIR_THRESHOLD: float = float(META_CONFIG.get("repair_threshold", 0.7))
 _REFLEX_CONF = META_CONFIG.get("reflex_override", {})
@@ -65,11 +66,17 @@ IGNORE_MEMORY_SHAPE_CONSTRAINT: bool = bool(
 
 
 
+def set_llm_mode(mode: str) -> None:
+    """Override LLM mode at runtime."""
+    global LLM_MODE, OFFLINE_MODE
+    LLM_MODE = mode
+    OFFLINE_MODE = mode != "online"
+    META_CONFIG["llm_mode"] = mode
+
+
 def set_offline_mode(value: bool) -> None:
-    """Override offline mode at runtime."""
-    global OFFLINE_MODE
-    OFFLINE_MODE = value
-    META_CONFIG["llm_mode"] = "offline" if value else "online"
+    """Backward compatible setter for offline mode."""
+    set_llm_mode("offline" if value else "online")
 
 
 def set_repair_enabled(value: bool) -> None:
@@ -166,7 +173,7 @@ def print_runtime_config() -> None:
     """Print a summary of the current runtime configuration."""
     info = {
         "introspect": INTROSPECTION_ENABLED,
-        "llm_mode": "offline" if OFFLINE_MODE else "online",
+        "llm_mode": LLM_MODE,
         "use_memory": MEMORY_ENABLED,
         "self_repair": REPAIR_ENABLED,
         "regime_override": REFLEX_OVERRIDE_ENABLED,


### PR DESCRIPTION
## Summary
- support GGUF models in `llm_engine` and expose `repair_symbolic_rule`
- integrate local repair path in `self_repair`
- allow selecting `local` LLM mode through config/CLI
- default meta config now uses `local` LLM mode
- set GGUF path when running AGI solver

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest arc_solver/tests/test_self_repair.py::test_run_meta_repair_improves_program -q`

------
https://chatgpt.com/codex/tasks/task_e_68414b3d77cc8322bca8abace493b4c2