### PR TITLE
Fix abstract call in MGEL debug viewer

### DIFF
--- a/scripts/mgel_debug_view.py
+++ b/scripts/mgel_debug_view.py
@@ -186,7 +186,7 @@ def main() -> None:
     print_grid("Target Grid", target_grid, use_color=args.color)
 
     print("\n\U0001F9E0 Extracting Symbolic Rules...")
-    rule_programs = abstract(input_grid, target_grid)
+    rule_programs = abstract([input_grid, target_grid])
 
     if not rule_programs:
         print("\u274C No symbolic rules extracted.")


### PR DESCRIPTION
## Summary
- fix call to `abstract` in debug viewer to match `abstractor` interface

## Testing
- `pytest -q` *(fails: 43 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68416440fae48322a267ec380348c91d