### PR TITLE
Implement symbolic diff scoring

### DIFF
--- a/arc_solver/src/evaluation/metrics.py
+++ b/arc_solver/src/evaluation/metrics.py
@@ -12,6 +12,11 @@ def accuracy_score(predicted: Grid, target: Grid) -> float:
     return predicted.compare_to(target)
 
 
+def symbolic_accuracy_score(predicted: Grid, target: Grid) -> float:
+    """Return pattern-aware accuracy using :meth:`Grid.detailed_score`."""
+    return predicted.detailed_score(target)
+
+
 def task_score(preds: List[Grid], targets: List[Grid]) -> float:
     """Return the proportion of grids predicted exactly."""
     if not preds or not targets:
@@ -27,4 +32,9 @@ def aggregate_accuracy(task_scores: List[float]) -> float:
     """Return mean accuracy over multiple tasks."""
     return sum(task_scores) / len(task_scores) if task_scores else 0.0
 
-__all__ = ["accuracy_score", "task_score", "aggregate_accuracy"]
+__all__ = [
+    "accuracy_score",
+    "task_score",
+    "aggregate_accuracy",
+    "symbolic_accuracy_score",
+]

--- a/arc_solver/src/scoring/__init__.py
+++ b/arc_solver/src/scoring/__init__.py
@@ -10,6 +10,7 @@ from .compositional import (
     justify_selection,
     run_pipeline,
 )
+from .diff_penalty import SymbolicDiffPenaltyEngine
 
 __all__ = [
     "RuleInfo",
@@ -20,4 +21,5 @@ __all__ = [
     "compose_programs",
     "justify_selection",
     "run_pipeline",
+    "SymbolicDiffPenaltyEngine",
 ]

--- a/arc_solver/src/scoring/diff_penalty.py
+++ b/arc_solver/src/scoring/diff_penalty.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Penalty based symbolic scoring utilities."""
+
+from dataclasses import dataclass
+from typing import Tuple, Dict
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.executor.simulator import simulate_rules
+from arc_solver.src.symbolic.vocabulary import SymbolicRule
+
+
+@dataclass
+class SymbolicDiffPenaltyEngine:
+    """Compute pattern-aware scores for predicted grids."""
+
+    zone_weight: float = 0.3
+    symbol_weight: float = 0.1
+
+    def score(self, predicted: Grid, target: Grid) -> Tuple[float, Dict[str, float]]:
+        """Return (score, summary) comparing ``predicted`` and ``target``."""
+        summary = predicted.diff_summary(target)
+        score = predicted.detailed_score(target)
+        summary["score"] = score
+        return score, summary
+
+    def evaluate_rule(self, rule: SymbolicRule, inp: Grid, tgt: Grid) -> Tuple[float, Dict[str, float]]:
+        """Simulate ``rule`` on ``inp`` and evaluate against ``tgt``."""
+        pred = simulate_rules(inp, [rule])
+        return self.score(pred, tgt)
+
+__all__ = ["SymbolicDiffPenaltyEngine"]

--- a/arc_solver/tests/test_detailed_score.py
+++ b/arc_solver/tests/test_detailed_score.py
@@ -1,0 +1,23 @@
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic import Symbol, SymbolType
+
+
+def test_diff_summary_basic():
+    g1 = Grid([[1, 2], [3, 4]])
+    g2 = Grid([[1, 2], [4, 4]])
+    overlay = [[Symbol(SymbolType.ZONE, "A"), Symbol(SymbolType.ZONE, "A")],
+               [Symbol(SymbolType.ZONE, "B"), Symbol(SymbolType.ZONE, "B")]]
+    g1.attach_overlay(overlay)
+    g2.attach_overlay(overlay)
+    summary = g1.diff_summary(g2)
+    assert summary["cell_match_ratio"] == 0.75
+    assert summary["zone_coverage_match"] == 1.0
+    assert summary["symbol_mismatch_count"] == 0
+
+
+def test_detailed_score_range():
+    g1 = Grid([[1, 0], [0, 1]])
+    g2 = Grid([[1, 1], [0, 1]])
+    score = g1.detailed_score(g2)
+    assert 0.0 <= score <= 1.0
+    assert score < 1.0

--- a/scripts/mgel_debug_view.py
+++ b/scripts/mgel_debug_view.py
@@ -217,7 +217,9 @@ def main() -> None:
         try:
             pred_grid = simulate_rules(input_grid, [rule])
             print_grid("Predicted Grid", pred_grid, use_color=args.color)
-            score = pred_grid.compare_to(target_grid)
+            from arc_solver.src.scoring.diff_penalty import SymbolicDiffPenaltyEngine
+            engine = SymbolicDiffPenaltyEngine()
+            score, diff = engine.score(pred_grid, target_grid)
             print(f"\u2705 Prediction Score: {score:.3f}")
             print_grid_diff(pred_grid, target_grid, use_color=args.color)
             metrics = {}
@@ -245,6 +247,7 @@ def main() -> None:
                 "grid_target": target_grid.data,
                 "trace_summary": metrics if metrics else {},
                 "grid_diff": diff_grid,
+                "diff_summary": diff,
             }
             if score > best_score:
                 best_result = candidate


### PR DESCRIPTION
## Summary
- compute diff summaries and weighted symbolic scores in `Grid`
- expose a symbolic accuracy metric
- add a `SymbolicDiffPenaltyEngine` for advanced scoring
- enhance simulator logging for debug introspection
- update MGEL scripts to report diff summaries
- test the new scoring utilities

## Testing
- `PYTHONPATH=. pytest arc_solver/tests/test_detailed_score.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684265224290832283f1123921947003