### PR TITLE
Add zone coverage handling and rule cascade

### DIFF
--- a/arc_solver/configs/meta_config.yaml
+++ b/arc_solver/configs/meta_config.yaml
@@ -26,4 +26,4 @@ regime_thresholds:
   entropy_low: 0.1
   zone_alignment_cutoff: 0.3
   symmetry_cutoff: 0.5
-zone_coverage_threshold: 0.6
+zone_coverage_threshold: 0.65

--- a/arc_solver/src/abstractions/abstractor.py
+++ b/arc_solver/src/abstractions/abstractor.py
@@ -129,8 +129,84 @@ def generate_fallback_rules(pair: Tuple[Grid, Grid]) -> List[SymbolicRule]:
         r.meta["fallback_reason"] = "no_rule_found"
     return fallback_templates
 
-from arc_solver.src.segment.segmenter import zone_overlay
+from arc_solver.src.segment.segmenter import zone_overlay, expand_zone_overlay
 from arc_solver.src.executor.simulator import simulate_rules
+from arc_solver.src.utils import config_loader
+
+
+def zone_change_coverage_map(
+    input_grid: Grid,
+    output_grid: Grid,
+    overlay: List[List[Optional[Symbol]]],
+) -> Dict[str, float]:
+    """Return mapping of zone label to change coverage ratio."""
+    h = len(overlay)
+    w = len(overlay[0]) if h else 0
+    totals: Dict[str, int] = {}
+    changed: Dict[str, int] = {}
+    for r in range(h):
+        for c in range(w):
+            sym = overlay[r][c]
+            if sym is None:
+                continue
+            zone = sym.value
+            totals[zone] = totals.get(zone, 0) + 1
+            if input_grid.get(r, c) != output_grid.get(r, c):
+                changed[zone] = changed.get(zone, 0) + 1
+    return {z: changed.get(z, 0) / totals[z] for z in totals}
+
+
+def fuse_low_entropy_zones(
+    overlay: List[List[Optional[Symbol]]],
+    grid: Grid,
+    entropies: Dict[str, float],
+    threshold: float = 0.2,
+) -> List[List[Optional[Symbol]]]:
+    """Return ``overlay`` with adjacent low-entropy zones fused."""
+    if overlay is None:
+        return overlay
+
+    h = len(overlay)
+    w = len(overlay[0]) if h else 0
+    zone_cells: Dict[str, List[int]] = {}
+    for r in range(h):
+        for c in range(w):
+            sym = overlay[r][c]
+            if sym is None:
+                continue
+            zone_cells.setdefault(sym.value, []).append(grid.get(r, c))
+
+    dominant = {z: max(vals, key=vals.count) for z, vals in zone_cells.items() if vals}
+
+    def adjacent(z1: str, z2: str) -> bool:
+        for r in range(h):
+            for c in range(w):
+                sym = overlay[r][c]
+                if sym is None or sym.value != z1:
+                    continue
+                for dr, dc in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+                    nr, nc = r + dr, c + dc
+                    if 0 <= nr < h and 0 <= nc < w:
+                        sym2 = overlay[nr][nc]
+                        if sym2 is not None and sym2.value == z2:
+                            return True
+        return False
+
+    zones = list(zone_cells.keys())
+    for i, z1 in enumerate(zones):
+        for z2 in zones[i + 1 :]:
+            if (
+                entropies.get(z1, 1.0) < threshold
+                and entropies.get(z2, 1.0) < threshold
+                and dominant.get(z1) == dominant.get(z2)
+                and adjacent(z1, z2)
+            ):
+                for r in range(h):
+                    for c in range(w):
+                        if overlay[r][c] is not None and overlay[r][c].value == z2:
+                            overlay[r][c] = Symbol(SymbolType.ZONE, z1)
+                entropies.pop(z2, None)
+    return overlay
 
 
 # ---------------------------------------------------------------------------
@@ -181,15 +257,19 @@ def extract_color_change_rules(
 
     # Zone-aware extraction
     zone_maps: Dict[str, Dict[int, set[int]]] = {}
+    zone_totals: Dict[str, int] = {}
+    zone_changes: Dict[str, int] = {}
     for r in range(h):
         for c in range(w):
             zone_sym = zone_overlay[r][c]
             if zone_sym is None:
                 continue
             zone = zone_sym.value
+            zone_totals[zone] = zone_totals.get(zone, 0) + 1
             src = input_grid.get(r, c)
             tgt = output_grid.get(r, c)
             if src != tgt:
+                zone_changes[zone] = zone_changes.get(zone, 0) + 1
                 zmap = zone_maps.setdefault(zone, {})
                 zmap.setdefault(src, set()).add(tgt)
 
@@ -236,6 +316,10 @@ def extract_color_change_rules(
                     "heuristic_used": "color_change",
                     "zone_entropy": ent,
                 }
+                coverage = zone_changes.get(zone, 0) / zone_totals.get(zone, 1)
+                rule.meta["zone_coverage"] = coverage
+                if coverage < config_loader.ZONE_COVERAGE_THRESHOLD:
+                    rule.condition.pop("zone", None)
                 rules.append(rule)
     return rules
 
@@ -251,12 +335,16 @@ def extract_zonewise_rules(
 
     h, w = input_grid.shape()
     zone_mappings: Dict[str, Dict[int, set[int]]] = {}
+    zone_totals: Dict[str, int] = {}
+    zone_changes: Dict[str, int] = {}
     for r in range(h):
         for c in range(w):
             zone = zone_overlay[r][c].value
+            zone_totals[zone] = zone_totals.get(zone, 0) + 1
             src = input_grid.get(r, c)
             tgt = output_grid.get(r, c)
             if src != tgt:
+                zone_changes[zone] = zone_changes.get(zone, 0) + 1
                 zone_map = zone_mappings.setdefault(zone, {})
                 zone_map.setdefault(src, set()).add(tgt)
 
@@ -265,17 +353,20 @@ def extract_zonewise_rules(
         for src_color, tgts in mapping.items():
             if len(tgts) == 1:
                 tgt_color = next(iter(tgts))
-                rules.append(
-                    SymbolicRule(
-                        transformation=Transformation(TransformationType.REPLACE),
-                        source=[
-                            Symbol(SymbolType.ZONE, zone),
-                            Symbol(SymbolType.COLOR, str(src_color)),
-                        ],
-                        target=[Symbol(SymbolType.COLOR, str(tgt_color))],
-                        nature=TransformationNature.LOGICAL,
-                    )
+                rule = SymbolicRule(
+                    transformation=Transformation(TransformationType.REPLACE),
+                    source=[
+                        Symbol(SymbolType.ZONE, zone),
+                        Symbol(SymbolType.COLOR, str(src_color)),
+                    ],
+                    target=[Symbol(SymbolType.COLOR, str(tgt_color))],
+                    nature=TransformationNature.LOGICAL,
                 )
+                coverage = zone_changes.get(zone, 0) / zone_totals.get(zone, 1)
+                rule.meta["zone_coverage"] = coverage
+                if coverage < config_loader.ZONE_COVERAGE_THRESHOLD:
+                    rule.condition.pop("zone", None)
+                rules.append(rule)
     return rules
 
 
@@ -366,11 +457,31 @@ def split_rule_by_overlay(
     return new_rules
 
 
+def retest_rules_on_pairs(
+    rules: List[SymbolicRule], other_pairs: List[Tuple[Grid, Grid]]
+) -> None:
+    """Annotate ``rules`` with reliability across ``other_pairs``."""
+    if not other_pairs:
+        return
+    for rule in rules:
+        success = 0
+        total = 0
+        for inp, out in other_pairs:
+            try:
+                pred = simulate_rules(inp, [rule])
+            except Exception:
+                continue
+            total += 1
+            if pred == out:
+                success += 1
+        rule.meta["rule_reliability"] = success / total if total else 0.0
+
+
 # ---------------------------------------------------------------------------
 # Convenience wrapper
 # ---------------------------------------------------------------------------
 
-def abstract(objects, *, logger=None) -> List[SymbolicRule]:
+def abstract(objects, *, logger=None, other_pairs: Optional[List[Tuple[Grid, Grid]]] = None) -> List[SymbolicRule]:
     """Return symbolic abstractions of a grid pair.
 
     When ``logger`` is provided, messages describing which extraction heuristics
@@ -381,6 +492,12 @@ def abstract(objects, *, logger=None) -> List[SymbolicRule]:
 
     input_grid, output_grid = objects[0], objects[1]
     overlay, zone_info = segment_and_overlay(input_grid, output_grid)
+    if overlay is not None:
+        coverage_map = zone_change_coverage_map(input_grid, output_grid, overlay)
+        for z, cov in coverage_map.items():
+            if cov < config_loader.ZONE_COVERAGE_THRESHOLD:
+                overlay = expand_zone_overlay(overlay, z)
+        overlay = fuse_low_entropy_zones(overlay, input_grid, zone_info)
     try:
         rules: List[SymbolicRule] = []
         cc_rules = extract_color_change_rules(
@@ -389,7 +506,8 @@ def abstract(objects, *, logger=None) -> List[SymbolicRule]:
         if logger:
             logger.info(f"color_change_rules: {len(cc_rules)}")
         rules.extend(cc_rules)
-        shape_rules = extract_shape_based_rules(input_grid, output_grid)
+        mid_grid = simulate_rules(input_grid, cc_rules) if cc_rules else input_grid
+        shape_rules = extract_shape_based_rules(mid_grid, output_grid)
         if logger:
             logger.info(f"shape_based_rules: {len(shape_rules)}")
         rules.extend(shape_rules)
@@ -417,6 +535,8 @@ def abstract(objects, *, logger=None) -> List[SymbolicRule]:
         if hasattr(rule, "is_well_formed") and not rule.is_well_formed():
             continue
         filtered.append(rule)
+    if other_pairs:
+        retest_rules_on_pairs(filtered, other_pairs)
     return filtered
 
 
@@ -425,5 +545,6 @@ __all__ = [
     "extract_shape_based_rules",
     "extract_zonewise_rules",
     "split_rule_by_overlay",
+    "retest_rules_on_pairs",
     "abstract",
 ]


### PR DESCRIPTION
## Summary
- tune `zone_coverage_threshold` setting
- track zone change coverage and fuse low-entropy segments
- chain color and shape rules via intermediate grid
- allow reliability retests across other pairs

## Testing
- `pip install -e .`
- `pip install numpy scikit-learn PyYAML matplotlib`
- `pytest -k abstraction -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684275bb37288322a03ede2a0fb13927