### PR TITLE
Improve rule ranking heuristics

### DIFF
--- a/arc_solver/src/search/feature_mapper.py
+++ b/arc_solver/src/search/feature_mapper.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 
 from typing import List
 
-from arc_solver.src.symbolic.vocabulary import SymbolicRule, SymbolType
+from arc_solver.src.symbolic.vocabulary import (
+    SymbolicRule,
+    SymbolType,
+    TransformationType,
+)
 
 
 def map_features(grid):
@@ -14,8 +18,40 @@ def map_features(grid):
 
 
 def rule_feature_vector(rule: SymbolicRule) -> List[float]:
-    """Return simple heuristic features for ``rule``."""
+    """Return simple heuristic features for ``rule``.
+
+    The vector encodes:
+    ``token_count``      - number of symbols in the rule
+    ``zone``             - whether a zone condition is present
+    ``color_usage``      - count of color tokens
+    ``shape_usage``      - count of shape tokens
+    ``position``         - whether a position constraint is present
+    ``class_entropy``    - hashed transformation class indicator
+    """
+
+    token_count = float(len(rule.source) + len(rule.target))
     zone = 1.0 if rule.condition.get("zone") else 0.0
-    colors = len({s.value for s in rule.source + rule.target if s.type is SymbolType.COLOR})
-    transform = hash(rule.transformation.ttype.value) % 5
-    return [zone, float(colors), float(transform)]
+    color_usage = float(
+        sum(1 for s in rule.source + rule.target if s.type is SymbolType.COLOR)
+    )
+    shape_usage = float(
+        sum(1 for s in rule.source + rule.target if s.type is SymbolType.SHAPE)
+    )
+    position = 1.0 if rule.condition.get("position") else 0.0
+
+    # Simple hashed representation of the transformation type. This is not a
+    # true entropy measure but provides diversity across classes without
+    # requiring explicit one-hot encoding.
+    if isinstance(rule.transformation.ttype, TransformationType):
+        class_entropy = float(hash(rule.transformation.ttype.value) % 7) / 7.0
+    else:  # pragma: no cover - defensive
+        class_entropy = 0.0
+
+    return [
+        token_count,
+        zone,
+        color_usage,
+        shape_usage,
+        position,
+        class_entropy,
+    ]

--- a/arc_solver/src/search/rule_ranker.py
+++ b/arc_solver/src/search/rule_ranker.py
@@ -2,10 +2,62 @@ from __future__ import annotations
 
 """Simple heuristics for ranking sets of symbolic rules."""
 
+import math
+from pathlib import Path
 from typing import List
+
+import yaml
 
 from arc_solver.src.memory.policy_cache import PolicyCache
 from arc_solver.src.symbolic.vocabulary import SymbolicRule
+from arc_solver.src.symbolic.rule_language import rule_to_dsl
+from arc_solver.src.search.feature_mapper import rule_feature_vector
+
+
+_MOTIF_PATH = Path(__file__).resolve().parents[2] / "configs" / "motif_db.yaml"
+
+
+def _load_motifs(path: Path = _MOTIF_PATH) -> List[dict]:
+    """Load motif rules from ``path`` if available."""
+    if not path.exists():
+        return []
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or []
+    except Exception:  # pragma: no cover - best effort
+        return []
+
+
+def _tokenize(text: str) -> List[str]:
+    for ch in "[],()":
+        text = text.replace(ch, " ")
+    return [t for t in text.lower().split() if t]
+
+
+def _cosine(a: List[str], b: List[str]) -> float:
+    """Cosine similarity between token lists."""
+    if not a or not b:
+        return 0.0
+    vocab = set(a) | set(b)
+    vec_a = [a.count(tok) for tok in vocab]
+    vec_b = [b.count(tok) for tok in vocab]
+    dot = sum(x * y for x, y in zip(vec_a, vec_b))
+    norm_a = math.sqrt(sum(x * x for x in vec_a))
+    norm_b = math.sqrt(sum(y * y for y in vec_b))
+    return dot / (norm_a * norm_b) if norm_a and norm_b else 0.0
+
+
+_MOTIFS = _load_motifs()
+
+
+def _motif_bonus(rule: SymbolicRule, threshold: float = 0.6) -> float:
+    """Return a small bonus if ``rule`` matches a known motif."""
+    tokens = _tokenize(rule_to_dsl(rule))
+    for m in _MOTIFS:
+        mtokens = _tokenize(str(m.get("rule_dsl", "")))
+        if _cosine(tokens, mtokens) >= threshold:
+            return 0.2
+    return 0.0
 
 
 def rank_rule_sets(
@@ -15,13 +67,26 @@ def rank_rule_sets(
 ) -> List[List[SymbolicRule]]:
     """Return ``rule_sets`` sorted by heuristic score."""
 
+    def _rule_score(rule: SymbolicRule) -> float:
+        feats = rule_feature_vector(rule)
+        dsl_len = len(rule_to_dsl(rule))
+        cond_complexity = len(rule.condition) if rule.condition else 0
+        minimality = -0.01 * dsl_len - 0.1 * cond_complexity
+        prior_bonus = _motif_bonus(rule)
+        return sum(feats) + minimality + prior_bonus
+
     def score(rs: List[SymbolicRule]) -> tuple:
-        coverage = len(rs)
-        diversity = len({r.transformation.ttype for r in rs})
-        abstractness = -sum(len(r.source) + len(r.target) for r in rs)
+        base = len(rs) + len({r.transformation.ttype for r in rs})
+        scores = [_rule_score(r) for r in rs]
+        if scores:
+            mean = sum(scores) / len(scores)
+            var = sum((s - mean) ** 2 for s in scores) / len(scores)
+            stab = mean - var
+        else:
+            stab = 0.0
         reuse = 0
         if policy_cache and task_hash and policy_cache.is_failed(task_hash, rs):
             reuse = -1
-        return (reuse, coverage, diversity, abstractness)
+        return (reuse, stab + base)
 
     return sorted(rule_sets, key=score, reverse=True)


### PR DESCRIPTION
## Summary
- expand rule feature vectors with token count and more usage details
- rank rulesets by minimality and motif similarity
- load motifs from `configs/motif_db.yaml`

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427d7368dc83229057bd92891d1fef