### PR TITLE
Add validate_trace wrapper and fix introspection imports

### DIFF
--- a/arc_solver/src/introspection/__init__.py
+++ b/arc_solver/src/introspection/__init__.py
@@ -3,7 +3,7 @@
 
 from .trace_builder import RuleTrace, build_trace
 from .symbolic_trace import SymbolicTrace
-from .introspective_validator import validate_trace
+from .validate_trace import validate_trace
 from .narrator_llm import narrate_trace
 from .refinement import (
     FeedbackSignal,

--- a/arc_solver/src/introspection/refinement.py
+++ b/arc_solver/src/introspection/refinement.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import List
 
 from arc_solver.src.core.grid import Grid
-from arc_solver.src.executor.simulator import simulate_rules
 from arc_solver.src.symbolic import (
     Symbol,
     SymbolType,
@@ -153,6 +152,8 @@ def llm_refine_program(trace: RuleTrace, feedback: FeedbackSignal) -> List[Symbo
 
 def evaluate_refinements(rules: List[SymbolicRule], grid_in: Grid, grid_out: Grid) -> SymbolicRule:
     """Return the candidate rule with the highest score."""
+
+    from arc_solver.src.executor.simulator import simulate_rules
 
     best_rule = rules[0]
     best_score = -1.0

--- a/arc_solver/src/introspection/self_repair.py
+++ b/arc_solver/src/introspection/self_repair.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
 from arc_solver.src.core.grid import Grid
-from arc_solver.src.executor.simulator import simulate_rules
 from arc_solver.src.symbolic.vocabulary import (
     Symbol,
     SymbolType,
@@ -67,6 +66,7 @@ class RuleTraceEntry:
 
 def trace_prediction(rule_set: List[SymbolicRule], input_grid: Grid) -> List[RuleTraceEntry]:
     """Apply ``rule_set`` sequentially and record rule activations."""
+    from arc_solver.src.executor.simulator import simulate_rules
     grid = Grid([row[:] for row in input_grid.data])
     traces: List[RuleTraceEntry] = []
     for i, rule in enumerate(rule_set):
@@ -204,6 +204,7 @@ def evaluate_repair_candidates(
     candidates: List[SymbolicRule], input_grid: Grid, target: Grid
 ) -> SymbolicRule:
     """Return the candidate yielding the highest similarity."""
+    from arc_solver.src.executor.simulator import simulate_rules
     best = candidates[0]
     best_score = -1.0
     for rule in candidates:
@@ -222,6 +223,8 @@ def run_meta_repair(
     rules: List[SymbolicRule],
 ) -> Tuple[Grid, List[SymbolicRule]]:
     """Return improved prediction and rule set via discrepancy mining."""
+
+    from arc_solver.src.executor.simulator import simulate_rules
 
     original_score = predicted.compare_to(ground_truth)
     discrepancy = compute_discrepancy(predicted, ground_truth)

--- a/arc_solver/src/introspection/validate_trace.py
+++ b/arc_solver/src/introspection/validate_trace.py
@@ -1,0 +1,20 @@
+"""Extended trace validation wrapper."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .trace_builder import RuleTrace
+from .introspective_validator import validate_trace as _validate_trace
+
+
+def validate_trace(trace: RuleTrace) -> Dict[str, Any]:
+    """Return validation metrics for ``trace``.
+
+    This thin wrapper exists for backward compatibility and forwards
+    to :func:`introspective_validator.validate_trace`.
+    """
+    return _validate_trace(trace)
+
+
+__all__ = ["validate_trace"]


### PR DESCRIPTION
## Summary
- avoid import cycles in introspection by deferring simulator imports
- expose `validate_trace` from new wrapper module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68427d8768488322abc8d2277928fea3