### PR TITLE
Add trace explanations to MGEL batch output

### DIFF
--- a/arc_solver/src/introspection/__init__.py
+++ b/arc_solver/src/introspection/__init__.py
@@ -22,6 +22,17 @@ from .self_repair import (
     RuleTraceEntry,
     FaultHypothesis,
 )
+from arc_solver.src.symbolic.rule_language import rule_to_dsl
+
+
+def suggest_fix_from_trace(trace: RuleTrace) -> str:
+    """Return DSL suggestion to repair ``trace.rule`` based on mismatches."""
+
+    if trace.ground_truth is None:
+        return ""
+    discrepancy = compute_discrepancy(trace.predicted_grid, trace.ground_truth)
+    fix = refine_rule(trace.rule, discrepancy)
+    return rule_to_dsl(fix) if fix else ""
 
 __all__ = [
     "RuleTrace",
@@ -42,4 +53,5 @@ __all__ = [
     "run_meta_repair",
     "RuleTraceEntry",
     "FaultHypothesis",
+    "suggest_fix_from_trace",
 ]


### PR DESCRIPTION
## Summary
- enhance trace validator with entropy metrics
- expose helper `suggest_fix_from_trace`
- enrich `mgel_batch_runner` results with detailed trace info, failure flagging and fix suggestions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'arc_solver')*

------
https://chatgpt.com/codex/tasks/task_e_68427dd2d0048322a1f31a746fa6cdbd