### PR TITLE
Implement grid analysis utilities

### DIFF
--- a/arc_solver/src/evaluation/__init__.py
+++ b/arc_solver/src/evaluation/__init__.py
@@ -1,1 +1,11 @@
 from .metrics import accuracy_score, task_score, aggregate_accuracy
+from .analysis import grid_diff_heatmap, entropy_change, save_failure_case
+
+__all__ = [
+    "accuracy_score",
+    "task_score",
+    "aggregate_accuracy",
+    "grid_diff_heatmap",
+    "entropy_change",
+    "save_failure_case",
+]

--- a/arc_solver/src/evaluation/analysis.py
+++ b/arc_solver/src/evaluation/analysis.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Visualization and analysis helpers for ARC solver evaluation."""
+
+import json
+from pathlib import Path
+from typing import Tuple
+
+import matplotlib
+matplotlib.use("Agg")  # ensure headless operation for tests
+import matplotlib.pyplot as plt
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.utils.grid_utils import compute_grid_entropy
+
+
+def grid_diff_heatmap(
+    predicted: Grid, target: Grid, *, return_data: bool = False
+) -> Tuple[plt.Figure, list[list[int]] | None]:
+    """Return a heatmap showing mismatched cells between ``predicted`` and ``target``."""
+
+    if predicted.shape() != target.shape():
+        raise ValueError("grid shapes must match")
+
+    h, w = predicted.shape()
+    heat = [
+        [1 if predicted.get(r, c) != target.get(r, c) else 0 for c in range(w)]
+        for r in range(h)
+    ]
+
+    fig = plt.figure()
+    plt.imshow(heat, cmap="Reds", interpolation="nearest")
+    plt.axis("off")
+    plt.tight_layout()
+
+    if return_data:
+        return fig, heat
+    return fig, None
+
+
+def entropy_change(input_grid: Grid, pred_grid: Grid) -> Tuple[float, float]:
+    """Return entropy of input and predicted grids for comparison."""
+
+    ent_in = compute_grid_entropy(input_grid)
+    ent_out = compute_grid_entropy(pred_grid)
+    return ent_in, ent_out
+
+
+def save_failure_case(
+    task_id: str,
+    index: int,
+    input_grid: Grid,
+    target_grid: Grid,
+    pred_grid: Grid,
+    score: float | None = None,
+    out_dir: str | Path = "failures",
+) -> None:
+    """Persist grids and metadata for inspection of failed predictions."""
+
+    case_dir = Path(out_dir) / f"{task_id}.csv"
+    case_dir.mkdir(parents=True, exist_ok=True)
+
+    def _save(grid: Grid, name: str) -> None:
+        fig = plt.figure(figsize=(2, 2))
+        plt.imshow(grid.data, interpolation="nearest")
+        plt.axis("off")
+        plt.tight_layout()
+        fig.savefig(case_dir / f"{name}.png")
+        plt.close(fig)
+
+    _save(input_grid, "input")
+    _save(target_grid, "target")
+    _save(pred_grid, "pred")
+
+    meta = {
+        "task_id": task_id,
+        "index": index,
+        "score": score,
+        "entropy_in": compute_grid_entropy(input_grid),
+        "entropy_pred": compute_grid_entropy(pred_grid),
+    }
+
+    with open(case_dir / "metadata.json", "w", encoding="utf-8") as fh:
+        json.dump(meta, fh, indent=2)
+
+
+__all__ = ["grid_diff_heatmap", "entropy_change", "save_failure_case"]
+

--- a/arc_solver/src/regime/regime_classifier.py
+++ b/arc_solver/src/regime/regime_classifier.py
@@ -11,6 +11,7 @@ import logging
 from typing import Dict, List, Tuple, Optional
 
 from arc_solver.src.core.grid import Grid
+from arc_solver.src.utils.grid_utils import compute_grid_entropy
 from arc_solver.src.segment.segmenter import zone_overlay
 from arc_solver.src.abstractions.abstractor import _find_translation
 from arc_solver.src.utils import config_loader
@@ -32,15 +33,8 @@ _SIGNATURE_INDEX = Path("logs/task_signature_index.json")
 
 
 def _grid_entropy(grid: Grid) -> float:
-    counts = grid.count_colors()
-    total = sum(counts.values())
-    ent = 0.0
-    for v in counts.values():
-        if v == 0:
-            continue
-        p = v / total
-        ent -= p * math.log2(p)
-    return ent
+    """Alias for :func:`compute_grid_entropy` (for backward compatibility)."""
+    return compute_grid_entropy(grid)
 
 
 def compute_task_signature(

--- a/arc_solver/src/utils/grid_utils.py
+++ b/arc_solver/src/utils/grid_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Tuple
+import math
 
 from arc_solver.src.core.grid import Grid
 
@@ -49,4 +50,17 @@ def validate_grid(grid: Grid, expected_shape: Tuple[int, int] | None = None) -> 
     return True
 
 
-__all__ = ["rotate", "validate_grid"]
+def compute_grid_entropy(grid: Grid) -> float:
+    """Return the Shannon entropy of the color distribution in ``grid``."""
+    counts = grid.count_colors()
+    total = sum(counts.values())
+    ent = 0.0
+    for v in counts.values():
+        if v == 0:
+            continue
+        p = v / total
+        ent -= p * math.log2(p)
+    return ent
+
+
+__all__ = ["rotate", "validate_grid", "compute_grid_entropy"]

--- a/arc_solver/tests/test_analysis.py
+++ b/arc_solver/tests/test_analysis.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.evaluation.analysis import (
+    grid_diff_heatmap,
+    entropy_change,
+    save_failure_case,
+)
+from arc_solver.src.utils.grid_utils import compute_grid_entropy
+
+
+def test_compute_grid_entropy_values():
+    g1 = Grid([[1, 1], [1, 1]])
+    g2 = Grid([[1, 2], [3, 4]])
+    assert compute_grid_entropy(g1) == 0.0
+    ent = compute_grid_entropy(g2)
+    assert 1.9 < ent < 2.1
+
+
+def test_grid_diff_heatmap_data():
+    pred = Grid([[1, 2], [3, 4]])
+    tgt = Grid([[1, 0], [3, 4]])
+    fig, heat = grid_diff_heatmap(pred, tgt, return_data=True)
+    assert heat == [[0, 1], [0, 0]]
+    fig.clf()
+
+
+def test_save_failure_case(tmp_path: Path):
+    inp = Grid([[1]])
+    tgt = Grid([[2]])
+    pred = Grid([[3]])
+    save_failure_case("t1", 0, inp, tgt, pred, 0.0, out_dir=tmp_path)
+    case_dir = tmp_path / "t1.csv"
+    assert (case_dir / "input.png").exists()
+    assert (case_dir / "target.png").exists()
+    assert (case_dir / "pred.png").exists()
+    meta = json.loads((case_dir / "metadata.json").read_text())
+    assert meta["task_id"] == "t1"
+


### PR DESCRIPTION
## Summary
- compute grid entropy util
- add analysis helpers for heatmap visualization and entropy change
- store failure case artifacts
- expose new APIs
- test analysis module

## Testing
- `pip install -q matplotlib pytest numpy pyyaml scikit-learn`
- `pip install -e .`
- `pytest arc_solver/tests/test_analysis.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427debde1c83229bd6b0778389b89b