### PR TITLE
Implement reliability-based memory filtering

### DIFF
--- a/arc_solver/configs/meta_config.yaml
+++ b/arc_solver/configs/meta_config.yaml
@@ -18,6 +18,7 @@ use_structural_attention: true
 structural_attention_weight: 0.2
 lazy_memory: false
 memory_similarity_threshold: 0.80
+memory_reliability_threshold: 0.75
 memory_diagnostics: true
 ignore_memory_shape_constraint: true
 sparse_mode: false

--- a/arc_solver/src/memory/__init__.py
+++ b/arc_solver/src/memory/__init__.py
@@ -9,6 +9,7 @@ from .memory_store import (
     get_best_memory_match,
     extract_task_constraints,
     get_last_load_stats,
+    update_memory_stats,
     preload_memory_from_kaggle_input,
 )
 
@@ -21,6 +22,7 @@ __all__ = [
     "get_best_memory_match",
     "extract_task_constraints",
     "get_last_load_stats",
+    "update_memory_stats",
     "preload_memory_from_kaggle_input",
 ]
 

--- a/arc_solver/src/utils/config_loader.py
+++ b/arc_solver/src/utils/config_loader.py
@@ -57,6 +57,9 @@ LAZY_MEMORY_LOADING: bool = bool(META_CONFIG.get("lazy_memory", False))
 MEMORY_SIMILARITY_THRESHOLD: float = float(
     META_CONFIG.get("memory_similarity_threshold", 0.95)
 )
+MEMORY_RELIABILITY_THRESHOLD: float = float(
+    META_CONFIG.get("memory_reliability_threshold", 0.75)
+)
 MEMORY_DIAGNOSTICS: bool = bool(META_CONFIG.get("memory_diagnostics", False))
 SPARSE_MODE: bool = bool(META_CONFIG.get("sparse_mode", False))
 FALLBACK_ON_ABSTRACTION_FAIL: bool = bool(
@@ -169,6 +172,13 @@ def set_ignore_memory_shape_constraint(value: bool) -> None:
     global IGNORE_MEMORY_SHAPE_CONSTRAINT
     IGNORE_MEMORY_SHAPE_CONSTRAINT = value
     META_CONFIG["ignore_memory_shape_constraint"] = value
+
+
+def set_memory_reliability_threshold(value: float) -> None:
+    """Override memory reliability filter threshold."""
+    global MEMORY_RELIABILITY_THRESHOLD
+    MEMORY_RELIABILITY_THRESHOLD = value
+    META_CONFIG["memory_reliability_threshold"] = value
 
 
 def print_runtime_config() -> None:


### PR DESCRIPTION
## Summary
- tune meta config for rule memory reliability
- expose reliability threshold config helpers
- store reliability meta in memory program entries
- filter/prune memory programs on reliability and failure stats
- test reliability filtering and pruning behaviour

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427da1f394832293abb127ba8dfee0