### PR TITLE
Add rule coverage prioritization to simulator

### DIFF
--- a/arc_solver/src/utils/__init__.py
+++ b/arc_solver/src/utils/__init__.py
@@ -1,4 +1,5 @@
 from .signature_extractor import extract_task_signature, similarity_score
 from .grid_utils import validate_grid
+from .coverage import rule_coverage
 
-__all__ = ["extract_task_signature", "similarity_score", "validate_grid"]
+__all__ = ["extract_task_signature", "similarity_score", "validate_grid", "rule_coverage"]

--- a/arc_solver/src/utils/coverage.py
+++ b/arc_solver/src/utils/coverage.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Rule coverage utilities."""
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic.vocabulary import SymbolicRule
+
+
+def rule_coverage(rule: SymbolicRule, grid: Grid) -> int:
+    """Return the number of cells that would change if ``rule`` is applied."""
+    from arc_solver.src.executor import simulator as _sim
+
+    if not _sim.validate_rule_application(rule, grid):
+        return 0
+    try:
+        tentative = _sim.check_symmetry_break(rule, grid)
+    except _sim.ReflexOverrideException:
+        return 0
+    h, w = grid.shape()
+    count = 0
+    for r in range(h):
+        for c in range(w):
+            if grid.get(r, c) != tentative.get(r, c):
+                count += 1
+    return count
+
+
+__all__ = ["rule_coverage"]

--- a/arc_solver/tests/test_rule_prioritization.py
+++ b/arc_solver/tests/test_rule_prioritization.py
@@ -1,0 +1,37 @@
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.executor.simulator import simulate_rules
+from arc_solver.src.symbolic.vocabulary import (
+    Symbol,
+    SymbolType,
+    SymbolicRule,
+    Transformation,
+    TransformationType,
+)
+
+
+def _rule(src: int, tgt: int, **cond) -> SymbolicRule:
+    return SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, str(src))],
+        target=[Symbol(SymbolType.COLOR, str(tgt))],
+        condition=cond,
+    )
+
+
+def test_prioritize_by_coverage():
+    grid = Grid([[1, 1, 1], [1, 1, 1], [1, 1, 1]])
+    small = _rule(1, 3, zone="TopLeft")
+    big = _rule(1, 2)
+    out = simulate_rules(grid, [small, big])
+    for r in range(3):
+        for c in range(3):
+            assert out.get(r, c) == 2
+
+
+def test_skip_zero_coverage():
+    grid = Grid([[1, 1], [1, 1]])
+    rule = _rule(1, 2, zone="TopLeft")
+    out = simulate_rules(grid, [rule])
+    for r in range(2):
+        for c in range(2):
+            assert out.get(r, c) == 1


### PR DESCRIPTION
## Summary
- compute rule coverage using new `rule_coverage` helper
- sort rules by coverage and skip zero-coverage rules
- expose helper in utils
- test prioritization behavior

## Testing
- `pytest arc_solver/tests/test_rule_prioritization.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684284605f208322912b45f77f66d4f0