### PR TITLE
Add softmask rule simulator with conflict suppression

### DIFF
--- a/arc_solver/src/core/__init__.py
+++ b/arc_solver/src/core/__init__.py
@@ -1,0 +1,7 @@
+"""Core grid utilities and data structures."""
+
+from .grid import Grid
+from .grid_utils import compute_conflict_map
+
+__all__ = ["Grid", "compute_conflict_map"]
+

--- a/arc_solver/src/core/grid_utils.py
+++ b/arc_solver/src/core/grid_utils.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Low-level grid utilities."""
+
+from typing import List
+
+from .grid import Grid
+
+
+def compute_conflict_map(before: Grid, after: Grid) -> List[List[int]]:
+    """Return map of cell conflicts between ``before`` and ``after`` grids."""
+    h1, w1 = before.shape()
+    h2, w2 = after.shape()
+    h = max(h1, h2)
+    w = max(w1, w2)
+    conflict: List[List[int]] = [[0 for _ in range(w)] for _ in range(h)]
+    for r in range(h):
+        for c in range(w):
+            if before.get(r, c, None) != after.get(r, c, None):
+                conflict[r][c] = 1
+    return conflict
+
+
+__all__ = ["compute_conflict_map"]
+

--- a/arc_solver/src/symbolic/vocabulary.py
+++ b/arc_solver/src/symbolic/vocabulary.py
@@ -146,6 +146,34 @@ class SymbolicRule:
             return False
         return True
 
+    def apply(self, grid: "Grid") -> "Grid":
+        """Return grid after applying this rule without strict checks."""
+        from arc_solver.src.executor.simulator import safe_apply_rule
+
+        return safe_apply_rule(self, grid, perform_checks=False)
+
+    def triggers_large_conflict(
+        self, conflict_map: list[list[int]], radius: int = 2
+    ) -> bool:
+        """Return True if conflict region exceeds ``radius`` heuristically."""
+        points = [
+            (r, c)
+            for r, row in enumerate(conflict_map)
+            for c, v in enumerate(row)
+            if v
+        ]
+        if not points:
+            return False
+        rmin = min(p[0] for p in points)
+        rmax = max(p[0] for p in points)
+        cmin = min(p[1] for p in points)
+        cmax = max(p[1] for p in points)
+        if (rmax - rmin) > radius or (cmax - cmin) > radius:
+            return True
+        if len(points) > (radius + 1) ** 2:
+            return True
+        return False
+
 
 __all__ = [
     "SymbolType",


### PR DESCRIPTION
## Summary
- add `compute_conflict_map` util and export it from `arc_solver.core`
- extend `SymbolicRule` with `apply` and `triggers_large_conflict`
- implement `simulate_rules_with_softmask` that filters rules causing large conflicts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68428dbc9d6c8322b734589f85f1b1fb