### PR TITLE
Add visual similarity scoring for rule reranking

### DIFF
--- a/arc_solver/src/executor/full_pipeline.py
+++ b/arc_solver/src/executor/full_pipeline.py
@@ -34,6 +34,7 @@ from arc_solver.src.memory.deep_prior_loader import (
     match_task_signature_to_prior,
     select_motifs,
 )
+from arc_solver.src.introspection.visual_scoring import rerank_by_visual_score
 from arc_solver.src.meta_generalizer import generalize_rule_program
 from arc_solver.src.symbolic.rule_language import parse_rule
 from arc_solver.src.executor.fallback_predictor import predict as fallback_predict
@@ -258,6 +259,12 @@ def solve_task(
         if logger:
             logger.info(f"candidate {rules_to_program(rs)} score={base:.3f}")
     prioritized = prioritize(candidate_sets, scores)
+    if prioritized and train_pairs:
+        prioritized = rerank_by_visual_score(
+            prioritized,
+            train_pairs[0][0],
+            train_pairs[0][1],
+        ) or prioritized
     if prioritized:
         best_rules = prioritized[0]
     if logger:

--- a/arc_solver/src/introspection/__init__.py
+++ b/arc_solver/src/introspection/__init__.py
@@ -22,6 +22,7 @@ from .self_repair import (
     RuleTraceEntry,
     FaultHypothesis,
 )
+from .visual_scoring import compute_visual_score, rerank_by_visual_score
 from arc_solver.src.symbolic.rule_language import rule_to_dsl
 
 
@@ -53,5 +54,7 @@ __all__ = [
     "run_meta_repair",
     "RuleTraceEntry",
     "FaultHypothesis",
+    "compute_visual_score",
+    "rerank_by_visual_score",
     "suggest_fix_from_trace",
 ]

--- a/arc_solver/src/introspection/visual_scoring.py
+++ b/arc_solver/src/introspection/visual_scoring.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Utilities for visually scoring predicted grids."""
+
+from typing import List
+
+import numpy as np
+from skimage.metrics import structural_similarity as ssim
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.executor.simulator import simulate_rules
+
+
+def compute_visual_score(pred_grid: Grid, target_grid: Grid) -> float:
+    """Return a structural similarity score between two grids."""
+    pred_np = np.array(pred_grid.data)
+    tgt_np = np.array(target_grid.data)
+    min_dim = min(pred_np.shape[0], pred_np.shape[1])
+    if min_dim < 3:
+        return pred_grid.compare_to(target_grid)
+    win = min(7, min_dim)
+    if win % 2 == 0:
+        win -= 1
+    data_range = float(
+        max(pred_np.max(), tgt_np.max()) - min(pred_np.min(), tgt_np.min())
+    ) or 1.0
+    score, _ = ssim(pred_np, tgt_np, win_size=win, data_range=data_range, full=True)
+    return float(score)
+
+
+def rerank_by_visual_score(
+    rule_sets: List[List],
+    input_grid: Grid,
+    target_grid: Grid,
+) -> List[List]:
+    """Order ``rule_sets`` by visual similarity of their predictions."""
+    ranked = []
+    for rules in rule_sets:
+        try:
+            pred = simulate_rules(input_grid, rules)
+            visual_score = compute_visual_score(pred, target_grid)
+            ranked.append((visual_score, rules))
+        except Exception:
+            continue
+    ranked.sort(key=lambda x: x[0], reverse=True)
+    return [r for _, r in ranked]
+
+
+__all__ = ["compute_visual_score", "rerank_by_visual_score"]

--- a/arc_solver/tests/test_visual_scoring.py
+++ b/arc_solver/tests/test_visual_scoring.py
@@ -1,0 +1,25 @@
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.introspection.visual_scoring import compute_visual_score, rerank_by_visual_score
+from arc_solver.src.symbolic import Symbol, SymbolType, SymbolicRule, Transformation, TransformationType
+
+
+def _rule(src: int, tgt: int) -> SymbolicRule:
+    return SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, str(src))],
+        target=[Symbol(SymbolType.COLOR, str(tgt))],
+    )
+
+
+def test_compute_visual_score_perfect_match():
+    g = Grid([[1, 2], [3, 4]])
+    assert compute_visual_score(g, g) == 1.0
+
+
+def test_rerank_by_visual_score():
+    inp = Grid([[1, 1], [1, 1]])
+    tgt = Grid([[2, 2], [2, 2]])
+    rule1 = _rule(1, 2)
+    rule2 = _rule(1, 3)
+    ranked = rerank_by_visual_score([[rule2], [rule1]], inp, tgt)
+    assert ranked and ranked[0][0].target[0].value == str(2)


### PR DESCRIPTION
## Summary
- implement SSIM based grid scoring in `visual_scoring`
- expose new scoring helpers in introspection package
- rerank candidate rule sets by visual similarity in `solve_task`
- add unit tests for new scoring utilities

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68428dcbb8388322bffb3d67a1b687ea