### PR TITLE
Add entropy-based memory rule validation

### DIFF
--- a/arc_solver/src/memory/memory_store.py
+++ b/arc_solver/src/memory/memory_store.py
@@ -363,3 +363,35 @@ def preload_memory_from_kaggle_input() -> None:
 
 __all__.append("preload_memory_from_kaggle_input")
 
+
+def validate_memory_program(memory_rule: SymbolicRule, current_input_grid: Any) -> bool:
+    """Return ``True`` if ``memory_rule`` aligns with high-entropy zones."""
+    from arc_solver.src.utils.entropy import compute_zone_entropy_map
+    from arc_solver.src.symbolic.overlay import zone_overlap_score
+
+    entropy_map = compute_zone_entropy_map(current_input_grid)
+    memory_zone = memory_rule.condition.get("zone")
+
+    if memory_zone:
+        score = zone_overlap_score(memory_zone, entropy_map)
+        if score < 0.4:
+            return False
+    return True
+
+
+def inject_reliable_memory_rules(memory_candidates: List[SymbolicRule], current_input_grid: Any) -> List[SymbolicRule]:
+    """Return rules passing reliability and zone validation checks."""
+    valid_rules: List[SymbolicRule] = []
+    for rule in memory_candidates:
+        reliability = rule.meta.get("rule_reliability", 1.0)
+        if reliability < 0.6:
+            continue
+        if not validate_memory_program(rule, current_input_grid):
+            continue
+        valid_rules.append(rule)
+    return valid_rules
+
+
+__all__.append("validate_memory_program")
+__all__.append("inject_reliable_memory_rules")
+

--- a/arc_solver/src/symbolic/overlay.py
+++ b/arc_solver/src/symbolic/overlay.py
@@ -1,0 +1,13 @@
+"""Simple overlay scoring utilities."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+def zone_overlap_score(zone_label: str, entropy_map: Dict[str, float]) -> float:
+    """Return normalized entropy score for ``zone_label``."""
+    return float(entropy_map.get(zone_label, 0.0))
+
+
+__all__ = ["zone_overlap_score"]

--- a/arc_solver/src/utils/entropy.py
+++ b/arc_solver/src/utils/entropy.py
@@ -1,0 +1,49 @@
+"""Entropy computation helpers for zone-based heuristics."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+import math
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.segment.segmenter import zone_overlay
+
+
+def _shannon_entropy(values: List[int]) -> float:
+    """Return Shannon entropy of the provided color values."""
+    counts: Dict[int, int] = {}
+    for v in values:
+        counts[v] = counts.get(v, 0) + 1
+    total = len(values)
+    ent = 0.0
+    for c in counts.values():
+        p = c / total
+        ent -= p * math.log2(p)
+    return ent
+
+
+def compute_zone_entropy_map(grid: Grid) -> Dict[str, float]:
+    """Return normalized entropy per predefined grid zone."""
+    overlay = zone_overlay(grid)
+    h = len(overlay)
+    w = len(overlay[0]) if h else 0
+    zone_cells: Dict[str, List[int]] = {}
+    for r in range(h):
+        for c in range(w):
+            sym = overlay[r][c]
+            if sym is None:
+                continue
+            zone_cells.setdefault(sym.value, []).append(grid.get(r, c))
+
+    max_ent = math.log2(10)
+    entropies: Dict[str, float] = {}
+    for zone, cells in zone_cells.items():
+        if not cells:
+            entropies[zone] = 0.0
+            continue
+        ent = _shannon_entropy(cells)
+        entropies[zone] = ent / max_ent if max_ent else ent
+    return entropies
+
+
+__all__ = ["compute_zone_entropy_map"]

--- a/arc_solver/tests/test_memory_validation.py
+++ b/arc_solver/tests/test_memory_validation.py
@@ -1,0 +1,74 @@
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic.vocabulary import (
+    Symbol,
+    SymbolType,
+    SymbolicRule,
+    Transformation,
+    TransformationType,
+)
+from arc_solver.src.memory.memory_store import (
+    validate_memory_program,
+    inject_reliable_memory_rules,
+)
+from arc_solver.src.symbolic.overlay import zone_overlap_score
+from arc_solver.src.utils.entropy import compute_zone_entropy_map
+
+
+def _make_rule(zone: str, reliability: float = 1.0) -> SymbolicRule:
+    rule = SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "2")],
+        condition={"zone": zone},
+    )
+    rule.meta["rule_reliability"] = reliability
+    return rule
+
+
+def test_zone_entropy_computation_and_overlap():
+    grid = Grid(
+        [
+            [1, 2, 3, 0, 0, 0],
+            [4, 5, 6, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+        ]
+    )
+    ent_map = compute_zone_entropy_map(grid)
+    assert ent_map
+    score = zone_overlap_score("TopLeft", ent_map)
+    assert 0.5 < score <= 1.0
+
+
+def test_validate_memory_program_zone_mismatch():
+    grid = Grid(
+        [
+            [1, 1, 0, 0, 0, 0],
+            [1, 1, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+        ]
+    )
+    rule = _make_rule("TopLeft")
+    assert not validate_memory_program(rule, grid)
+
+
+def test_inject_reliable_memory_rules_filters():
+    grid = Grid(
+        [
+            [1, 2, 3, 0, 0, 0],
+            [4, 5, 6, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+        ]
+    )
+    good = _make_rule("TopLeft", reliability=0.8)
+    bad = _make_rule("TopLeft", reliability=0.4)
+    out = inject_reliable_memory_rules([good, bad], grid)
+    assert good in out and bad not in out


### PR DESCRIPTION
## Summary
- add entropy calculation helpers in utils.entropy
- provide zone overlap scoring utility
- discard unreliable memory rules that don't target high entropy zones
- test memory rule validation against entropy map

## Testing
- `pytest arc_solver/tests/test_memory_validation.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428dc3cae08322a8ef19ede65bd89d