### PR TITLE
Fix submission schema for ARC-AGI

### DIFF
--- a/scripts/mgel_leaderboard_submit.py
+++ b/scripts/mgel_leaderboard_submit.py
@@ -59,7 +59,7 @@ def _predict_task(task: ARCAGITask):
         best, fallback_rules = [], []
 
     outputs = []
-    for test_input in task.test[:2]:
+    for test_input in task.test:
         try:
             p1 = simulate_rules(test_input, best) if best else fallback_predict(test_input)
         except Exception:


### PR DESCRIPTION
## Summary
- ensure build_submission_json outputs attempt dicts without `output` wrapper
- run solver on all test inputs in mgel leaderboard script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'arc_solver')*

------
https://chatgpt.com/codex/tasks/task_e_686d3d765e488322b182153447c2d01d