### PR TITLE
Handle CompositeRule in dependency utilities

### DIFF
--- a/arc_solver/src/executor/dependency.py
+++ b/arc_solver/src/executor/dependency.py
@@ -8,16 +8,17 @@ from arc_solver.src.symbolic.vocabulary import (
     SymbolicRule,
     TransformationType,
 )
+from arc_solver.src.symbolic.rule_language import CompositeRule
 
 
 class RuleDependencyGraph:
     """Simple undirected conflict graph between rules."""
 
-    def __init__(self, rules: List[SymbolicRule]) -> None:
+    def __init__(self, rules: List[SymbolicRule | CompositeRule]) -> None:
         self.edges: Dict[int, Set[int]] = defaultdict(set)
         self.build(rules)
 
-    def build(self, rules: List[SymbolicRule]) -> None:
+    def build(self, rules: List[SymbolicRule | CompositeRule]) -> None:
         for i, r1 in enumerate(rules):
             for j, r2 in enumerate(rules):
                 if i >= j:
@@ -26,21 +27,38 @@ class RuleDependencyGraph:
                     self.edges[i].add(j)
                     self.edges[j].add(i)
 
-def rule_dependency_graph(rules: List[SymbolicRule]) -> Dict[int, Set[int]]:
+def rule_dependency_graph(rules: List[SymbolicRule | CompositeRule]) -> Dict[int, Set[int]]:
     """Return a directed dependency graph between rules."""
+
+    def _targets(rule: SymbolicRule | CompositeRule) -> Set[str]:
+        if isinstance(rule, CompositeRule):
+            t: Set[str] = set()
+            for step in rule.steps:
+                t.update(s.value for s in step.target if s.type is SymbolType.COLOR)
+            return t
+        return {s.value for s in rule.target if s.type is SymbolType.COLOR}
+
+    def _sources(rule: SymbolicRule | CompositeRule) -> Set[str]:
+        if isinstance(rule, CompositeRule):
+            s: Set[str] = set()
+            for step in rule.steps:
+                s.update(sy.value for sy in step.source if sy.type is SymbolType.COLOR)
+            return s
+        return {s.value for s in rule.source if s.type is SymbolType.COLOR}
+
     graph: Dict[int, Set[int]] = defaultdict(set)
     for i, r1 in enumerate(rules):
-        targets = {s.value for s in r1.target if s.type is SymbolType.COLOR}
+        targets = _targets(r1)
         for j, r2 in enumerate(rules):
             if i == j:
                 continue
-            sources = {s.value for s in r2.source if s.type is SymbolType.COLOR}
+            sources = _sources(r2)
             if targets & sources:
                 graph[i].add(j)
     return graph
 
 
-def sort_rules_by_dependency(rules: List[SymbolicRule]) -> List[SymbolicRule]:
+def sort_rules_by_dependency(rules: List[SymbolicRule | CompositeRule]) -> List[SymbolicRule | CompositeRule]:
     """Return ``rules`` sorted by dependency order."""
     graph = rule_dependency_graph(rules)
     indegree: Dict[int, int] = {i: 0 for i in range(len(rules))}
@@ -60,13 +78,26 @@ def sort_rules_by_dependency(rules: List[SymbolicRule]) -> List[SymbolicRule]:
     return [rules[i] for i in order]
 
 
-def sort_rules_by_topology(rules: List[SymbolicRule]) -> List[SymbolicRule]:
+def sort_rules_by_topology(rules: List[SymbolicRule | CompositeRule]) -> List[SymbolicRule | CompositeRule]:
     """Return ``rules`` ordered respecting zone and color dependencies."""
-    zone_groups: Dict[str | None, List[SymbolicRule]] = defaultdict(list)
+
+    zone_groups: Dict[str | None, List[SymbolicRule | CompositeRule]] = defaultdict(list)
+
     for rule in rules:
-        zone = rule.condition.get("zone") if rule.condition else None
+        zone: str | None = None
+        if isinstance(rule, CompositeRule):
+            zones = {
+                step.condition.get("zone")
+                for step in rule.steps
+                if step.condition and "zone" in step.condition
+            }
+            if len(zones) == 1:
+                zone = next(iter(zones))
+        else:
+            zone = rule.condition.get("zone") if rule.condition else None
         zone_groups[zone].append(rule)
-    ordered: List[SymbolicRule] = []
+
+    ordered: List[SymbolicRule | CompositeRule] = []
     for key in sorted(zone_groups.keys(), key=lambda z: "" if z is None else str(z)):
         ordered.extend(sort_rules_by_dependency(zone_groups[key]))
     return ordered
@@ -79,7 +110,7 @@ def _extract_color(rule: SymbolicRule) -> str | None:
     return None
 
 
-def has_conflict(r1: SymbolicRule, r2: SymbolicRule) -> bool:
+def _has_conflict_simple(r1: SymbolicRule, r2: SymbolicRule) -> bool:
     zone1 = r1.condition.get("zone") if r1.condition else None
     zone2 = r2.condition.get("zone") if r2.condition else None
     if zone1 and zone2 and zone1 != zone2:
@@ -98,9 +129,21 @@ def has_conflict(r1: SymbolicRule, r2: SymbolicRule) -> bool:
     return False
 
 
-def select_independent_rules(rules: List[SymbolicRule]) -> List[SymbolicRule]:
+def has_conflict(r1: SymbolicRule | CompositeRule, r2: SymbolicRule | CompositeRule) -> bool:
+    if isinstance(r1, CompositeRule) or isinstance(r2, CompositeRule):
+        steps1 = r1.steps if isinstance(r1, CompositeRule) else [r1]
+        steps2 = r2.steps if isinstance(r2, CompositeRule) else [r2]
+        for s1 in steps1:
+            for s2 in steps2:
+                if _has_conflict_simple(s1, s2):
+                    return True
+        return False
+    return _has_conflict_simple(r1, r2)
+
+
+def select_independent_rules(rules: List[SymbolicRule | CompositeRule]) -> List[SymbolicRule | CompositeRule]:
     graph = RuleDependencyGraph(rules)
-    chosen: List[SymbolicRule] = []
+    chosen: List[SymbolicRule | CompositeRule] = []
     for idx, rule in enumerate(rules):
         if any(j in graph.edges.get(idx, set()) for j in range(len(chosen))):
             continue

--- a/arc_solver/tests/test_dependency_composite.py
+++ b/arc_solver/tests/test_dependency_composite.py
@@ -1,0 +1,37 @@
+import pytest
+from arc_solver.src.executor.dependency import (
+    sort_rules_by_dependency,
+    select_independent_rules,
+)
+from arc_solver.src.symbolic import (
+    Symbol,
+    SymbolType,
+    SymbolicRule,
+    Transformation,
+    TransformationType,
+)
+from arc_solver.src.symbolic.rule_language import CompositeRule
+
+
+def _color_rule(src: int, tgt: int) -> SymbolicRule:
+    return SymbolicRule(
+        Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, str(src))],
+        target=[Symbol(SymbolType.COLOR, str(tgt))],
+    )
+
+
+def test_sort_rules_with_composite():
+    r1 = _color_rule(1, 2)
+    r2 = _color_rule(2, 3)
+    comp = CompositeRule([r1])
+    ordered = sort_rules_by_dependency([r2, comp])
+    assert ordered[0] is comp
+
+
+def test_select_independent_rules_composite():
+    r1 = _color_rule(1, 2)
+    r2 = _color_rule(1, 3)
+    comp = CompositeRule([r1])
+    selected = select_independent_rules([comp, r2])
+    assert len(selected) == 1


### PR DESCRIPTION
## Summary
- support CompositeRule in rule dependency graph and sorting functions
- ignore composite conflicts by checking individual steps
- test dependency utilities with CompositeRule inputs

## Testing
- `pytest arc_solver/tests/test_dependency_composite.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686db467acb08322bd9333dd955fadfa