### PR TITLE
Handle composite rules during generalization

### DIFF
--- a/arc_solver/tests/test_rule_generalization.py
+++ b/arc_solver/tests/test_rule_generalization.py
@@ -1,0 +1,22 @@
+import pytest
+from arc_solver.src.abstractions.rule_generator import generalize_rules
+from arc_solver.src.symbolic import Symbol, SymbolType, SymbolicRule, Transformation, TransformationType
+from arc_solver.src.symbolic.rule_language import CompositeRule
+from arc_solver.src.utils import config_loader
+
+
+def _color_rule(src: int, tgt: int) -> SymbolicRule:
+    return SymbolicRule(
+        Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, str(src))],
+        target=[Symbol(SymbolType.COLOR, str(tgt))],
+    )
+
+
+def test_generalize_rules_with_composite():
+    comp = CompositeRule([_color_rule(1, 2), _color_rule(2, 3)])
+    config_loader.set_sparse_mode(True)
+    rules = generalize_rules([comp])
+    config_loader.set_sparse_mode(False)
+    assert rules == [comp]
+


### PR DESCRIPTION
## Summary
- support `CompositeRule` objects in `generalize_rules`, `remove_duplicate_rules`, and `rule_cost`
- add regression test for composite rule generalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686db59a309c8322a824f00a27bc95ba