### PR TITLE
Composite rule integration fix

### DIFF
--- a/arc_solver/tests/test_composite_dependency_pass.py
+++ b/arc_solver/tests/test_composite_dependency_pass.py
@@ -1,0 +1,19 @@
+from arc_solver.src.symbolic.vocabulary import Symbol, SymbolType, SymbolicRule, Transformation, TransformationType
+from arc_solver.src.symbolic.rule_language import CompositeRule
+from arc_solver.src.executor.dependency import rule_dependency_graph
+
+
+def _rule(src: int, tgt: int) -> SymbolicRule:
+    return SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, str(src))],
+        target=[Symbol(SymbolType.COLOR, str(tgt))],
+    )
+
+
+def test_composite_rule_dependency_pass():
+    r1 = _rule(1, 2)
+    r2 = _rule(2, 3)
+    comp = CompositeRule([r1, r2])
+    graph = rule_dependency_graph([comp, r1])
+    assert isinstance(graph, dict)

--- a/arc_solver/tests/test_dependency_composite.py
+++ b/arc_solver/tests/test_dependency_composite.py
@@ -34,4 +34,4 @@ def test_select_independent_rules_composite():
     r2 = _color_rule(1, 3)
     comp = CompositeRule([r1])
     selected = select_independent_rules([comp, r2])
-    assert len(selected) == 1
+    assert selected == [r2, comp]

--- a/arc_solver/tests/test_phase6.py
+++ b/arc_solver/tests/test_phase6.py
@@ -54,4 +54,4 @@ def test_dependency_graph_select():
         target=[Symbol(SymbolType.COLOR, "3")],
     )
     selected = select_independent_rules([r1, r2])
-    assert len(selected) == 1
+    assert selected == [r2, r1]


### PR DESCRIPTION
## Summary
- expand `CompositeRule` with helper methods and symbolic proxy
- support composite rules in dependency graphs and selection utilities
- adjust rule selection in `solve_task`
- handle composite rules in simulator and feature mapping
- add regression test for composite dependency
- update conflict tests for new topological ordering

## Testing
- `PYTHONPATH=. pytest -q`
- `python - <<'EOF'
import json
from arc_solver.src.executor.full_pipeline import solve_task
with open('arc-agi_training_challenges.json') as f:
    tasks = json.load(f)
ids = list(tasks.keys())[1:3]
for tid in ids:
    preds, outs, traces, rules = solve_task(tasks[tid])
    print('task', tid, 'pred count', len(preds))
EOF`


------
https://chatgpt.com/codex/tasks/task_e_686dbbdebbd4832290a1216799a344cb