### PR TITLE
Update composite rule dependency handling

### DIFF
--- a/arc_solver/src/executor/dependency.py
+++ b/arc_solver/src/executor/dependency.py
@@ -8,7 +8,7 @@ from arc_solver.src.symbolic.vocabulary import (
     SymbolicRule,
     TransformationType,
 )
-from arc_solver.src.symbolic.rule_language import CompositeRule
+from arc_solver.src.symbolic.rule_language import CompositeRule, final_targets
 
 
 class RuleDependencyGraph:
@@ -32,7 +32,7 @@ def rule_dependency_graph(rules: List[Union[SymbolicRule, CompositeRule]]) -> Di
 
     graph: Dict[int, Set[int]] = {}
     for i, r1 in enumerate(rules):
-        s1 = r1.get_targets() if isinstance(r1, CompositeRule) else r1.target
+        s1 = final_targets(r1) if isinstance(r1, CompositeRule) else r1.target
         t1_colors = {s.value for s in s1 if s.type is SymbolType.COLOR}
         deps: Set[int] = set()
         for j, r2 in enumerate(rules):

--- a/arc_solver/src/symbolic/rule_language.py
+++ b/arc_solver/src/symbolic/rule_language.py
@@ -166,6 +166,7 @@ class CompositeRule:
         """Return merged target symbols across all steps."""
         return list({s for step in self.steps for s in getattr(step, "target", [])})
 
+
     def get_condition(self) -> Optional[Any]:
         """Return the first non-null condition among steps."""
         for step in self.steps:
@@ -193,6 +194,13 @@ class CompositeRule:
         return self.to_string()
 
 
+def final_targets(rule: CompositeRule) -> List[Symbol]:
+    """Return target symbols from the final step of ``rule``."""
+    if not rule.steps:
+        return []
+    return list(getattr(rule.steps[-1], "target", []))
+
+
 __all__ = [
     "parse_rule",
     "rule_to_dsl",
@@ -201,4 +209,5 @@ __all__ = [
     "validate_color_range",
     "clean_dsl_string",
     "CompositeRule",
+    "final_targets",
 ]

--- a/arc_solver/tests/test_dependency_multistep.py
+++ b/arc_solver/tests/test_dependency_multistep.py
@@ -1,0 +1,35 @@
+import logging
+from arc_solver.src.executor.dependency import sort_rules_by_dependency
+from arc_solver.src.executor.simulator import simulate_rules
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic import (
+    Symbol,
+    SymbolType,
+    SymbolicRule,
+    Transformation,
+    TransformationType,
+)
+from arc_solver.src.symbolic.rule_language import CompositeRule
+
+
+def _color_rule(src: int, tgt: int) -> SymbolicRule:
+    return SymbolicRule(
+        Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, str(src))],
+        target=[Symbol(SymbolType.COLOR, str(tgt))],
+    )
+
+
+def test_order_and_simulation_no_warning(caplog):
+    step1 = _color_rule(1, 2)
+    step2 = _color_rule(2, 3)
+    comp = CompositeRule([step1, step2])
+    rule = _color_rule(1, 4)
+    ordered = sort_rules_by_dependency([rule, comp])
+    assert ordered == [rule, comp]
+
+    grid = Grid([[1, 1], [1, 1]])
+    logger = logging.getLogger("dep_multi")
+    with caplog.at_level(logging.WARNING):
+        simulate_rules(grid, ordered, logger=logger)
+    assert not any("Source color" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add `final_targets` helper to `symbolic.rule_language` for final step targets
- use `final_targets` in `rule_dependency_graph`
- add regression test covering multistep composites

## Testing
- `pytest -q arc_solver/tests/test_dependency_multistep.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc2dc7d0483228d22ff493c13b18e