### PR TITLE
Implement color dependency validation pass

### DIFF
--- a/arc_solver/tests/test_simulator.py
+++ b/arc_solver/tests/test_simulator.py
@@ -1,6 +1,7 @@
 import logging
 from arc_solver.src.core.grid import Grid
 from arc_solver.src.executor.simulator import simulate_rules
+import pytest
 from arc_solver.src.symbolic.vocabulary import Symbol, SymbolType, SymbolicRule, Transformation, TransformationType
 
 
@@ -15,4 +16,39 @@ def test_replace_missing_source(caplog):
     with caplog.at_level(logging.WARNING):
         out = simulate_rules(grid, [rule], logger=logger)
     assert out.data == grid.data
-    assert any("Skipping rule" in rec.message for rec in caplog.records)
+    assert any("skipped" in rec.message for rec in caplog.records)
+
+
+def test_color_dependency_skip(caplog):
+    grid = Grid([[1]])
+    r1 = SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "2")],
+    )
+    r2 = SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "3")],
+    )
+    logger = logging.getLogger("dep_skip")
+    with caplog.at_level(logging.WARNING):
+        out = simulate_rules(grid, [r1, r2], logger=logger)
+    assert out.data == [[2]]
+    assert any("skipped" in rec.message for rec in caplog.records)
+
+
+def test_color_dependency_strict():
+    grid = Grid([[1]])
+    r1 = SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "2")],
+    )
+    r2 = SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "3")],
+    )
+    with pytest.raises(ValueError):
+        simulate_rules(grid, [r1, r2], strict=True)


### PR DESCRIPTION
## Summary
- add `validate_color_dependencies` to filter rules missing required colors
- validate rules in `simulate_rules` before executing
- expose the new function in module exports
- test color dependency handling and strict mode

## Testing
- `pytest -q arc_solver/tests/test_simulator.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_686dc6afce0083229bda2f8d205c13b2