### PR TITLE
Fix composite rule handling

### DIFF
--- a/arc_solver/src/executor/simulator.py
+++ b/arc_solver/src/executor/simulator.py
@@ -144,14 +144,19 @@ def validate_color_dependencies(
     valid: list[SymbolicRule | CompositeRule] = []
 
     for rule in rules:
-        src_syms = rule.get_sources() if isinstance(rule, CompositeRule) else rule.source
-        required: set[int] = set()
-        for s in src_syms:
-            if s.type is SymbolType.COLOR:
-                try:
-                    required.add(int(s.value))
-                except Exception:
-                    continue
+        if isinstance(rule, CompositeRule):
+            first_sources = rule.steps[0].source
+            required = {
+                int(s.value)
+                for s in first_sources
+                if s.type is SymbolType.COLOR
+            }
+        else:
+            required = {
+                int(s.value)
+                for s in rule.source
+                if s.type is SymbolType.COLOR
+            }
 
         missing = [c for c in required if c not in color_presence]
         if missing:

--- a/arc_solver/src/symbolic/rule_language.py
+++ b/arc_solver/src/symbolic/rule_language.py
@@ -177,12 +177,16 @@ class CompositeRule:
     def is_well_formed(self) -> bool:
         return all(getattr(step, "is_well_formed", lambda: False)() for step in self.steps)
 
+    def final_targets(self) -> List[Symbol]:
+        """Return target symbols from the final step."""
+        return self.steps[-1].target if self.steps else []
+
     def as_symbolic_proxy(self) -> SymbolicRule:
         """Create a SymbolicRule-like proxy for use in dependency utilities."""
         return SymbolicRule(
             transformation=self.transformation,
-            source=self.get_sources(),
-            target=self.get_targets(),
+            source=self.steps[0].source,
+            target=self.final_targets(),
             condition=self.get_condition() or {},
             nature=TransformationNature.SPATIAL,
         )
@@ -196,9 +200,7 @@ class CompositeRule:
 
 def final_targets(rule: CompositeRule) -> List[Symbol]:
     """Return target symbols from the final step of ``rule``."""
-    if not rule.steps:
-        return []
-    return list(getattr(rule.steps[-1], "target", []))
+    return rule.final_targets()
 
 
 __all__ = [

--- a/arc_solver/tests/test_dependency_composite.py
+++ b/arc_solver/tests/test_dependency_composite.py
@@ -35,3 +35,13 @@ def test_select_independent_rules_composite():
     comp = CompositeRule([r1])
     selected = select_independent_rules([comp, r2])
     assert selected == [r2, comp]
+
+
+def test_composite_dependency_ordering():
+    c1 = _color_rule(1, 2)
+    c2 = _color_rule(2, 3)
+    composite = CompositeRule([c1, c2])
+    r2 = _color_rule(2, 4)
+    rules = [composite, r2]
+    sorted_rules = select_independent_rules(rules)
+    assert sorted_rules.index(r2) < sorted_rules.index(composite)


### PR DESCRIPTION
## Summary
- check only first step sources when validating color dependencies
- track final targets of CompositeRules
- correct symbolic proxy sources/targets for dependency ordering
- test CompositeRule dependency ordering

## Testing
- `pytest arc_solver/tests/test_dependency_composite.py::test_composite_dependency_ordering -q`
- `pytest arc_solver/tests/test_dependency_composite.py -q`
- `python -m arc_solver.scripts.evaluate_agi_accuracy` *(fails: ModuleNotFoundError or other issues)*

------
https://chatgpt.com/codex/tasks/task_e_686dd5ba6e288322b3f7b51dc1c02195