### PR TITLE
Fix composite rule uncertainty tracking

### DIFF
--- a/arc_solver/tests/test_uncertainty_resize.py
+++ b/arc_solver/tests/test_uncertainty_resize.py
@@ -1,0 +1,19 @@
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic.vocabulary import SymbolicRule, Transformation, TransformationType, Symbol, SymbolType
+from arc_solver.src.executor.simulator import simulate_rules
+
+
+def test_uncertainty_grid_resizes():
+    inp = Grid([[1]])
+    repeat = SymbolicRule(
+        transformation=Transformation(TransformationType.REPEAT, params={"kx": "2", "ky": "2"}),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "1")],
+    )
+    replace = SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "2")],
+    )
+    out = simulate_rules(inp, [repeat, replace])
+    assert out.shape() == (2, 2)


### PR DESCRIPTION
## Summary
- resize uncertainty grid when composite rules enlarge the output
- prevent IndexError in `mark_conflict`
- skip invalid color values gracefully
- cover regression in new test

## Testing
- `pytest -q arc_solver/tests/test_uncertainty_resize.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686de0b271108322a0f8a3f4316d8261