### PR TITLE
Fix composite rule color validation

### DIFF
--- a/arc_solver/tests/test_simulator.py
+++ b/arc_solver/tests/test_simulator.py
@@ -1,8 +1,15 @@
 import logging
 from arc_solver.src.core.grid import Grid
-from arc_solver.src.executor.simulator import simulate_rules
+from arc_solver.src.executor.simulator import simulate_rules, validate_color_dependencies
 import pytest
-from arc_solver.src.symbolic.vocabulary import Symbol, SymbolType, SymbolicRule, Transformation, TransformationType
+from arc_solver.src.symbolic.vocabulary import (
+    Symbol,
+    SymbolType,
+    SymbolicRule,
+    Transformation,
+    TransformationType,
+)
+from arc_solver.src.symbolic.rule_language import CompositeRule
 
 
 def test_replace_missing_source(caplog):
@@ -52,3 +59,22 @@ def test_color_dependency_strict():
     )
     with pytest.raises(ValueError):
         simulate_rules(grid, [r1, r2], strict=True)
+
+
+def test_composite_chain_validation_accept():
+    grid = Grid([[1]])
+
+    step1 = SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "2")],
+    )
+    step2 = SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "2")],
+        target=[Symbol(SymbolType.COLOR, "3")],
+    )
+    comp = CompositeRule([step1, step2])
+
+    validated = validate_color_dependencies([comp], grid)
+    assert validated == [comp]


### PR DESCRIPTION
## Summary
- check composite rules step by step during color dependency validation
- log debug traces for each step
- test acceptance of sequential composite rules

## Testing
- `pytest arc_solver/tests/test_simulator.py arc_solver/tests/test_composite_repeat.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686de4f2f5b08322a9fe63faf12b42b6