### PR TITLE
Handle grid expansion in conflict marking

### DIFF
--- a/arc_solver/tests/test_simulator.py
+++ b/arc_solver/tests/test_simulator.py
@@ -78,3 +78,29 @@ def test_composite_chain_validation_accept():
 
     validated = validate_color_dependencies([comp], grid)
     assert validated == [comp]
+
+
+def test_conflict_resize_after_repeat():
+    inp = Grid([[1]])
+    repeat = SymbolicRule(
+        transformation=Transformation(
+            TransformationType.REPEAT, params={"kx": "2", "ky": "1"}
+        ),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "1")],
+    )
+    r1 = SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "2")],
+    )
+    r2 = SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "3")],
+    )
+    uncertainty = [[0]]
+    out = simulate_rules(inp, [repeat, r1, r2], uncertainty_grid=uncertainty)
+    assert out.shape() == (1, 2)
+    assert len(uncertainty) == 1 and len(uncertainty[0]) == 2
+    assert uncertainty[0][1] > 0


### PR DESCRIPTION
## Summary
- resize uncertainty grid in `mark_conflict` when output grid grows
- guard against IndexError and log debug resize events
- update simulator to pass grid context
- add regression test covering conflict marking after repeat expansion

## Testing
- `pytest arc_solver/tests/test_simulator.py::test_conflict_resize_after_repeat -q`
- `python instrument.py --task_id 00576224 --bundle arc-agi_training_challenges.json | head -n 12`

------
https://chatgpt.com/codex/tasks/task_e_686de6d409948322b7b460c07a881cab