### PR TITLE
Improve rule failure logging

### DIFF
--- a/arc_solver/src/executor/simulator.py
+++ b/arc_solver/src/executor/simulator.py
@@ -669,6 +669,7 @@ def safe_apply_rule(
     perform_checks: bool = True,
     *,
     lineage_tracker: ColorLineageTracker | None = None,
+    task_id: str | None = None,
 ) -> Grid:
     """Apply ``rule`` safely, returning ``grid`` unchanged on failure."""
     logger.debug(f"Executing rule: {rule}")
@@ -682,9 +683,23 @@ def safe_apply_rule(
         )
     except IndexError as exc:
         logger.warning(f"IndexError applying rule {rule}: {exc}")
+        log_rule_failure(
+            rule,
+            failure_type="IndexError",
+            message=str(exc),
+            grid_snapshot=grid.data,
+            task_id=task_id,
+        )
         return grid
     except Exception as exc:  # pragma: no cover - catch-all
         logger.warning(f"Rule application failed: {rule} — {exc}")
+        log_rule_failure(
+            rule,
+            failure_type="Exception",
+            message=str(exc),
+            grid_snapshot=grid.data,
+            task_id=task_id,
+        )
         return grid
 
 


### PR DESCRIPTION
## Summary
- log simulator errors with `log_rule_failure`
- preserve grids and propagate optional `task_id`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686df254d7e88322b73570b335646711