### PR TITLE
Update docs for new solver architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ python instrument.py --bundle arc-agi_training_challenges.json --task_id 0000000
 
 ## 6. Output & Logging
 
-Predicted grids for datasets are written to `submission.json`.  When `solve_task` runs with `debug=True` a detailed log file is created under `logs/` describing extracted rules, conflicts and scoring statistics.  Failures below a score threshold are appended to `logs/failure_log.json` for later inspection.
+Predicted grids for datasets are written to `submission.json`.  When `solve_task` runs with `debug=True` a detailed log file is created under `logs/` describing extracted rules, conflicts and scoring statistics.  Failures below a score threshold are appended to `logs/failure_log.jsonl` as JSON lines containing `intermediate_grids`, `color_lineage`, `rejection_stage` and other diagnostics.
 
 ## 7. Example Tasks & Visualizations
 
@@ -65,7 +65,6 @@ Sample notebooks in [`arc_solver/notebooks`](arc_solver/notebooks) demonstrate z
 
 ## 8. Known Issues / Future Work
 
-* Composite rules are still penalised by rule cost.  The scoring module mitigates this by dividing the penalty by the square root of the chain length when `prefer_composites` is enabled【F:arc_solver/src/executor/scoring.py†L6-L10】【F:arc_solver/src/executor/scoring.py†L88-L103】.
 * Conflict marking resizes the uncertainty grid to avoid `IndexError` when rules expand the working grid【F:arc_solver/src/executor/simulator.py†L128-L170】.
 * Some advanced scoring functions are placeholders (`TODO` in comments) and require tuning.
 

--- a/architecture.md
+++ b/architecture.md
@@ -5,30 +5,31 @@ The meta‑symbolic ARC solver infers a small program of symbolic rules for each
 1. **Input parsing** – Tasks are loaded as `Grid` pairs.  `solve_task` in [`executor/full_pipeline.py`](arc_solver/src/executor/full_pipeline.py) reads the JSON description and converts the examples to `Grid` objects.
 2. **Rule abstraction** – For each training pair `abstract()` from [`abstractions/abstractor.py`](arc_solver/src/abstractions/abstractor.py) generates candidate rules.  `generalize_rules()` and `remove_duplicate_rules()` in [`abstractions/rule_generator.py`](arc_solver/src/abstractions/rule_generator.py) clean and deduplicate the list.  Repeat based composites are produced via [`symbolic/repeat_rule.py`](arc_solver/src/symbolic/repeat_rule.py) and [`symbolic/composite_rules.py`](arc_solver/src/symbolic/composite_rules.py).
 3. **Rule scoring and selection** – Candidate sets are ranked using `probabilistic_rank_rule_sets()` and `score_rule()` functions.  Zone overlays from `segmenter.zone_overlay()` aid the attention masks.  The top set is optionally refined by visual scoring in [`introspection/visual_scoring.py`](arc_solver/src/introspection/visual_scoring.py).
-4. **Conflict resolution** – `simulate_rules()` in [`executor/simulator.py`](arc_solver/src/executor/simulator.py) sorts rules via dependency utilities and applies them while logging conflicts with `mark_conflict()`.  `validate_color_dependencies()` ensures that required source colours remain available.
+4. **Conflict resolution** – `simulate_rules()` in [`executor/simulator.py`](arc_solver/src/executor/simulator.py) sorts rules via dependency utilities and applies them while logging conflicts with `mark_conflict()`.  `validate_color_dependencies()` now simulates the entire composite chain and verifies colour sufficiency only after the final step, allowing intermediate colour loss.
 5. **Simulation** – Each rule is executed on the working grid.  Composite programs are expanded and validated by `simulate_composite_rule()` before application.
 6. **Prediction output** – The best rule program is run on the test grids to produce the final prediction list returned by `solve_task`.  Predictions are stored in `submission.json` for evaluation.
 
 ## 3. Composite Rule System
 `CompositeRule` (defined in [`symbolic/rule_language.py`](arc_solver/src/symbolic/rule_language.py)) represents a sequence of `SymbolicRule` steps.  They were introduced to capture multi‑step patterns such as repeat tiling followed by recolouring.  `generate_repeat_composite_rules()` in [`symbolic/composite_rules.py`](arc_solver/src/symbolic/composite_rules.py) constructs chains like `REPEAT → REPLACE` by inspecting intermediate grids.  During dependency filtering `CompositeRule.as_symbolic_proxy()` exposes a simplified view so that `select_independent_rules()` can schedule them alongside simple rules.
 
-Scoring aggregates the cost of each step via `rule_cost()` in [`abstractions/rule_generator.py`](arc_solver/src/abstractions/rule_generator.py).  Intermediate colours must remain valid across the chain; otherwise `validate_color_dependencies()` will drop the rule.  Bugs remain around checking colours after each step which can suppress viable composites when intermediate recolouring introduces new colours.
+Scoring aggregates similarity metrics and applies a small complexity penalty based on the number of unique operations in the rule.  Colour validation simulates the full composite chain and only checks colour sufficiency at the final step, so temporary recolouring no longer causes rejection.
 
 ## 4. Scoring System
 `executor/scoring.py` implements the heuristic formula used by `solve_task`:
 ```
-score = 0.6 * pixel_similarity + 0.3 * zone_match + 0.1 * shape_bonus
-score += 0.2 * improvement - 0.02 * rule_cost
+base = 0.6 * after_pixel + 0.3 * zone_match + 0.1 * shape_bonus
+if after_pixel > before_pixel:
+    base += 0.2 * (after_pixel - before_pixel)
+penalty = 0.005 * unique_ops
+bonus = 0.2 if isinstance(rule, CompositeRule) and base == 1.0 else 0.0
+final = base - penalty + bonus
 ```
-When `prefer_composites` is enabled the cost penalty is divided by the square root of the number of steps, reducing bias against long chains.
-Common causes of rejection are low coverage ratio and high rule cost which reduce the final score below 0.0.
+Negative scores are no longer clipped, allowing fine-grained ranking.
 
 ## 5. Debug and Instrumentation Flow
 [`instrument.py`](instrument.py) decorates rule generators and simulator helpers with simple print logging.  When `solve_task` is invoked with `debug=True` a per‑task logger is created (`get_logger()` from [`utils/logger.py`](arc_solver/src/utils/logger.py)) and detailed trace entries are written.  Conflict locations and zone mismatches are recorded through `mark_conflict()` and `rule_failures_log` inside `simulator.py`.
 
 ## 6. Known Limitations & Failure Cases
-* **Intermediate colour dependency** – composite rules may be discarded if a step introduces colours that are later replaced, because `validate_color_dependencies()` only checks current grid colours.
-* **Scoring suppression** – complex chains accumulate high `rule_cost` leading to low scores despite perfect matches.
 * **Grid expansion overflows** – applying translations or repeats can enlarge the grid beyond the working area.  `mark_conflict()` resizes the uncertainty grid to avoid `IndexError` but extreme cases still fail.
 * **Divergent predictions** – tasks such as `00576224` in `submission.json` show zero‑valued predictions where rules could not be validated against the training colours.
 

--- a/rule_language.md
+++ b/rule_language.md
@@ -153,5 +153,5 @@ result = safe_apply_rule(comp, grid)
 
 ## Limitations and Future Work
 
-The rule language currently focuses on colour and region manipulations. Shape abstraction and robust rotation handling are planned but not yet implemented. Composite rules may fail when intermediate colours disappear, and large repeat/translate steps can expand grids beyond the uncertainty map.
+The rule language currently focuses on colour and region manipulations. Shape abstraction and robust rotation handling are planned but not yet implemented. Large repeat/translate steps can expand grids beyond the uncertainty map.
 

--- a/scoring_system.md
+++ b/scoring_system.md
@@ -6,28 +6,22 @@ The scoring system ranks candidate rules by their expected contribution to solvi
 
 ```
 base = 0.6 * after_pixel + 0.3 * zone_match + 0.1 * shape_bonus
-base += 0.2 * improvement
-penalty = 0.02 * rule_cost
-final = base - penalty
+if after_pixel > before_pixel:
+    base += 0.2 * (after_pixel - before_pixel)
+penalty = 0.005 * unique_ops
+bonus = 0.2 if isinstance(rule, CompositeRule) and base == 1.0 else 0.0
+final = base - penalty + bonus
 ```
-Lines【F:arc_solver/src/executor/scoring.py†L87-L104】 detail this logic.  `after_pixel` is the raw grid match after applying the rule. `zone_match` measures how well labelled zones align, and `shape_bonus` rewards correct output shape.  `improvement` compares the predicted match against the input grid, giving up to `+0.2` extra credit.
+Lines【F:arc_solver/src/executor/scoring.py†L60-L109】 detail this logic. `after_pixel` is the raw grid match after applying the rule. `zone_match` measures how well labelled zones align, and `shape_bonus` rewards correct output shape. `unique_ops` counts the distinct operation types in the rule.
 
 ### 2.1 Penalty Terms
-`rule_cost()` from [`abstractions/rule_generator.py`](arc_solver/src/abstractions/rule_generator.py) assigns a heuristic cost based on zone length and DSL complexity:
+`unique_ops()` returns the number of distinct transformations used by a rule. This replaces the previous heavy dependence on `rule_cost`.
 
-```
-zone_size = len(zone_str)
-transform_complexity = len(rule_to_dsl(rule).split("->")[1])
-return 0.5 * zone_size + transform_complexity
-```
-【F:arc_solver/src/abstractions/rule_generator.py†L91-L98】
-The cost grows for longer conditions and more complex transformations.  Composite rules sum the cost of their steps.
+### 2.2 Composite Bonus
+A composite rule that perfectly matches the target receives a `+0.2` bonus.
 
-### 2.2 Composite Penalties
-By default the penalty multiplies the cost by `0.02`.  If the rule is a composite and `prefer_composites=True`, the penalty is divided by `sqrt(len(steps))` to lessen bias against long chains【F:arc_solver/src/executor/scoring.py†L95-L102】.
-
-### 2.3 Negative Clipping
-After penalties, scores are clipped into `[0.0, 1.0]` so negative values are truncated at zero【F:arc_solver/src/executor/scoring.py†L103-L108】.  This prevents runaway penalties but may hide useful signal from otherwise promising rules.
+### 2.3 Score Range
+Scores are no longer clipped to zero; negative values propagate to allow accurate ranking of poor candidates.
 
 ## 3. Scoring Functions
 ### score_rule()
@@ -47,15 +41,13 @@ rule <desc> raw=<raw> adj=<score> gain=<delta>
 Logging lines appear in the range【F:instrument.py†L92-L106】 and help trace why specific rules were kept or discarded.
 
 ## 6. Issues Observed
-* **Over‑penalisation of multi‑step rules** – long composites accumulate cost faster than their match score grows, leading to low final scores.
-* **Bias against composites** – even with `prefer_composites`, chains of more than two steps often score below short single rules.
-* **Negative clipping** – truncation at zero masks differences between failed but potentially useful rules, reducing learning signal.
+* **Bias against composites** – multi-step programs may still score slightly below atomic rules when similarity is imperfect.
 
 ## 7. Refinements & Suggestions
 Several refinements were applied or proposed:
-* **Dynamic cost adjustment** – reducing the penalty factor when the rule greatly improves the grid.
-* **Similarity boosting** – adding an improvement bonus as implemented in lines【F:arc_solver/src/executor/scoring.py†L90-L93】.
-* **Composite‑aware score normalization** – dividing the cost by `sqrt(steps)` when composites are preferred.
+* **Dynamic cost adjustment** – the penalty factor now uses the number of unique operations.
+* **Similarity boosting** – the improvement bonus remains capped at `+0.2`.
+* **Composite bonus** – perfect chains receive an explicit bonus instead of penalty scaling.
 
 ## 8. Scoring Philosophy
 The solver balances precision against generality.  A rule should explain as much of the output as possible without unnecessary complexity.  Penalties discourage overly specific or lengthy programs, while bonuses promote transformations that make substantial progress.  The scoring system therefore aims to select concise yet powerful rules that generalise across training examples.


### PR DESCRIPTION
## Summary
- document new color validation behavior across the docs
- update scoring formula description and penalties
- explain new fallback behaviour and failure log fields
- fix outdated limitations and known issues

## Testing
- `pytest -q` *(fails: 68 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686faa55b5d48322b5f56814dab3d9bd