### PR TITLE
Add color lineage validator

### DIFF
--- a/arc_solver/tests/test_validator.py
+++ b/arc_solver/tests/test_validator.py
@@ -1,6 +1,9 @@
 import pytest
 from arc_solver.src.core.grid import Grid
-from arc_solver.src.executor.validator import validate_color_dependencies
+from arc_solver.src.executor.validator import (
+    validate_color_dependencies,
+    validate_color_lineage,
+)
 from arc_solver.src.symbolic.vocabulary import Symbol, SymbolType, SymbolicRule, Transformation, TransformationType
 from arc_solver.src.symbolic.rule_language import CompositeRule
 
@@ -23,3 +26,30 @@ def test_validate_color_dependencies_fail():
     grid = Grid([[1, 2]])
     chain = [_rule(1, 3), _rule(3, 3)]
     assert not validate_color_dependencies(chain, grid)
+
+
+def test_validate_color_lineage_recolor_restore():
+    grid = Grid([[1]])
+    comp = CompositeRule([_rule(1, 2), _rule(2, 1)])
+    assert validate_color_lineage(comp, grid)
+
+
+def test_validate_color_lineage_erase_restore():
+    grid = Grid([[1]])
+    step1 = _rule(1, 0)
+    step2 = _rule(0, 1)
+    comp = CompositeRule([step1, step2])
+    assert validate_color_lineage(comp, grid)
+
+
+def test_validate_color_lineage_copy_paste_restore():
+    grid = Grid([[1]])
+    translate = SymbolicRule(
+        transformation=Transformation(
+            TransformationType.TRANSLATE, params={"dx": "0", "dy": "0"}
+        ),
+        source=[],
+        target=[],
+    )
+    comp = CompositeRule([_rule(1, 2), translate, _rule(2, 1)])
+    assert validate_color_lineage(comp, grid)


### PR DESCRIPTION
## Summary
- validate explicit colour restoration with `validate_color_lineage`
- log colour removals/reappearances for lineage analysis
- extend validator tests to cover recolour, erase and copy scenarios

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q arc_solver/tests/test_validator.py`

------
https://chatgpt.com/codex/tasks/task_e_686faf1a130c8322bcc27d53aba37220