### PR TITLE
Improve composite simulation safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Sample notebooks in [`arc_solver/notebooks`](arc_solver/notebooks) demonstrate z
 
 ## 8. Known Issues / Future Work
 
-* Conflict marking resizes the uncertainty grid to avoid `IndexError` when rules expand the working grid【F:arc_solver/src/executor/simulator.py†L128-L170】.
+* Conflict marking resizes the uncertainty grid to avoid `IndexError` when rules expand the working grid. `simulate_composite_safe()` forecasts growth beforehand to keep grids under `64x64`.
 * Some advanced scoring functions are placeholders (`TODO` in comments) and require tuning.
 
 ## 9. Developer Notes

--- a/architecture.md
+++ b/architecture.md
@@ -30,7 +30,7 @@ Negative scores are no longer clipped, allowing fine-grained ranking.
 [`instrument.py`](instrument.py) decorates rule generators and simulator helpers with simple print logging.  When `solve_task` is invoked with `debug=True` a per‑task logger is created (`get_logger()` from [`utils/logger.py`](arc_solver/src/utils/logger.py)) and detailed trace entries are written.  Conflict locations and zone mismatches are recorded through `mark_conflict()` and `rule_failures_log` inside `simulator.py`.
 
 ## 6. Known Limitations & Failure Cases
-* **Grid expansion overflows** – applying translations or repeats can enlarge the grid beyond the working area.  `mark_conflict()` resizes the uncertainty grid to avoid `IndexError` but extreme cases still fail.
+* **Grid expansion overflows** – composite steps now forecast growth and abort when exceeding `64x64`, resizing the uncertainty grid proactively when safe.
 * **Divergent predictions** – tasks such as `00576224` in `submission.json` show zero‑valued predictions where rules could not be validated against the training colours.
 
 ## 7. Design Philosophy

--- a/composite_rules.md
+++ b/composite_rules.md
@@ -25,17 +25,18 @@ Composite rules represent a chain of symbolic transformations executed as a sing
 * **Zone chain proxy** – `as_symbolic_proxy()` records `zone_chain` pairs so `sort_rules_by_topology()` can order composites based on zone transitions.【F:arc_solver/src/executor/proxy_ext.py†L41-L91】【F:arc_solver/src/executor/dependency.py†L69-L111】
 * **Color validation update** – composite chains are validated as a whole with colour sufficiency checked only after the final step.【F:arc_solver/src/executor/simulator.py†L212-L340】
 * **Scoring overhaul** – penalties depend only on unique operation types and perfect composites receive a +0.2 bonus.【F:arc_solver/src/executor/scoring.py†L60-L109】
+* **Grid growth forecast** – `simulate_composite_safe()` now predicts composite size using `grid_growth_forecast()` and aborts when the limit is exceeded.【F:arc_solver/src/executor/simulator.py†L60-L123】
 
 ## Remaining Failure Modes
 * Recolouring steps that introduce temporary colours can still cause validation rejection even after the lineage patch.
 * Proxy translation for advanced transformations (e.g. rotate within a composite) may misreport zones, leading to ordering mistakes.
-* Grid expansion by repeat steps occasionally exceeds the solver's safety limits, causing execution to abort.
+* Large grid expansions are validated ahead of time to avoid exceeding safety limits.
 
 ## Planned Mitigations
 * Further normalise cost for composites by weighting cost per unique transformation type.
 * Relax colour validation when subsequent steps explicitly replace the missing colours.
 * Expand `as_symbolic_proxy()` to include zone information of each step so dependency ordering can reason about spatial scopes.
-* Add boundary checks when expanding grids to safely resize the uncertainty map.
+* Implemented boundary checks and proactive uncertainty-map resizing when composites grow the grid.
 
 ## Stabilisation Suggestions
 * Provide unit tests covering longer chains and unusual colour sequences.

--- a/rule_language.md
+++ b/rule_language.md
@@ -153,5 +153,5 @@ result = safe_apply_rule(comp, grid)
 
 ## Limitations and Future Work
 
-The rule language currently focuses on colour and region manipulations. Shape abstraction and robust rotation handling are planned but not yet implemented. Large repeat/translate steps can expand grids beyond the uncertainty map.
+The rule language currently focuses on colour and region manipulations. Shape abstraction and robust rotation handling are planned but not yet implemented. Composite growth is checked via `grid_growth_forecast()` to keep the uncertainty map within bounds.
 


### PR DESCRIPTION
## Summary
- forecast grid growth before applying composite steps
- validate max grid size and log expansion failures
- expose new `ValidationError` and forecasting helper
- document updated safety behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fb9715e5c8322a7faad0f7c34df89