### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Meta-Symbolic ARC Solver System
 
+![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)
+
 ## 1. Project Overview
 
 This repository contains a symbolic solver for the [Abstraction and Reasoning Corpus (ARC)](https://github.com/arcprize/ARC-AGI-2).  The solver infers a set of symbolic rules from provided training examples and applies them to unseen test grids.  The design emphasises interpretability: rules are represented as structured `SymbolicRule` objects and can be chained into `CompositeRule` programs.  Recent updates added composite rule scoring, failure logging and a safer conflict tracking mechanism.
@@ -72,6 +74,7 @@ Sample notebooks in [`arc_solver/notebooks`](arc_solver/notebooks) demonstrate z
 ## 9. Developer Notes
 
 * Run `pytest` before submitting changes.  All current tests should pass (142 tests)【69a983†L1-L4】.
+* GitHub Actions CI validates the same 142 tests on every push.
 * Keep new modules under the existing `arc_solver/src` hierarchy.
 * Contributions that extend the rule vocabulary or improve the ranking heuristics are welcome; please document new behaviour in this README.
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for Python 3.11
- install package in editable mode and run tests
- cache pip dependencies
- display CI badge in README
- document that CI runs the 142 tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fd2092d68832298ebc3912a622a02