### PR TITLE
Enable multi-colour repeat composites

### DIFF
--- a/arc_solver/src/executor/scoring.py
+++ b/arc_solver/src/executor/scoring.py
@@ -16,7 +16,7 @@ from arc_solver.src.core.grid import Grid
 from arc_solver.src.executor.simulator import simulate_rules
 from arc_solver.src.executor.failure_logger import log_failure
 from arc_solver.src.symbolic.rule_language import CompositeRule
-from arc_solver.src.symbolic.vocabulary import SymbolicRule
+from arc_solver.src.symbolic.vocabulary import SymbolicRule, TransformationType
 
 
 # ---------------------------------------------------------------------------
@@ -62,6 +62,9 @@ def _unique_ops(rule: SymbolicRule | CompositeRule) -> int:
 
     if isinstance(rule, CompositeRule):
         return len({step.transformation.ttype for step in rule.steps}) or 1
+    if rule.transformation.ttype is TransformationType.COMPOSITE:
+        steps = rule.transformation.params.get("steps", [])
+        return len(set(steps)) or 1
     return 1
 
 

--- a/arc_solver/tests/test_repeat_composite_multi.py
+++ b/arc_solver/tests/test_repeat_composite_multi.py
@@ -1,0 +1,26 @@
+import pytest
+from arc_solver.src.symbolic.composite_rules import generate_repeat_composite_rules
+from arc_solver.src.symbolic.rule_language import CompositeRule
+from arc_solver.src.executor.scoring import score_rule
+from arc_solver.src.executor.simulator import validate_color_dependencies
+from arc_solver.src.core.grid import Grid
+
+
+def test_repeat_composite_multiple_mappings():
+    inp = Grid([[1, 2]])
+    out = Grid([[3, 4], [3, 4]])
+
+    rules = generate_repeat_composite_rules(inp, out)
+    assert len(rules) == 1
+
+    comp = rules[0]
+    assert isinstance(comp, CompositeRule)
+    # repeat + two replace steps
+    assert len(comp.steps) == 3
+    assert comp.simulate(inp).data == out.data
+
+    score = score_rule(inp, out, comp)
+    assert score > 0.9
+
+    validated = validate_color_dependencies([comp], inp)
+    assert validated == [comp]


### PR DESCRIPTION
## Summary
- support multiple recolour mappings when generating repeat composites
- count composite steps in rule scoring
- test multi-mapping composite generation, scoring and validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fd4ebbe5c8322ae3993ff755bfe8b