### PR TITLE
Implement composite cost normalisation

### DIFF
--- a/arc_solver/tests/test_cost_normalisation_real_task.py
+++ b/arc_solver/tests/test_cost_normalisation_real_task.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic.vocabulary import (
+    Symbol,
+    SymbolType,
+    SymbolicRule,
+    Transformation,
+    TransformationNature,
+    TransformationType,
+)
+from arc_solver.src.symbolic.rule_language import CompositeRule
+from arc_solver.src.executor.scoring import score_rule
+
+
+def test_cost_normalisation_real_task():
+    data = json.loads(Path("arc-agi_training_challenges.json").read_text())
+    pair = data["00576224"]["train"][0]
+    inp = Grid(pair["input"])
+    out = Grid(pair["output"])
+
+    repeat = SymbolicRule(
+        transformation=Transformation(
+            TransformationType.REPEAT,
+            params={"kx": "3", "ky": "3"},
+        ),
+        source=[Symbol(SymbolType.REGION, "All")],
+        target=[Symbol(SymbolType.REGION, "All")],
+        nature=TransformationNature.SPATIAL,
+    )
+
+    noop = SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "1")],
+    )
+
+    comp = CompositeRule([repeat, noop])
+
+    single = score_rule(inp, out, repeat, return_trace=True)
+    chained = score_rule(inp, out, comp, return_trace=True)
+
+    assert chained["penalty"] > single["penalty"]
+    assert chained["op_cost"] >= single["op_cost"]

--- a/architecture.md
+++ b/architecture.md
@@ -16,7 +16,7 @@ grid rotation.
 ## 3. Composite Rule System
 `CompositeRule` (defined in [`symbolic/rule_language.py`](arc_solver/src/symbolic/rule_language.py)) represents a sequence of `SymbolicRule` steps.  They were introduced to capture multi‑step patterns such as repeat tiling followed by recolouring.  `generate_repeat_composite_rules()` in [`symbolic/composite_rules.py`](arc_solver/src/symbolic/composite_rules.py) constructs chains like `REPEAT → REPLACE` by inspecting intermediate grids.  During dependency filtering `CompositeRule.as_symbolic_proxy()` exposes a simplified view so that `select_independent_rules()` can schedule them alongside simple rules.
 
-Scoring aggregates similarity metrics and applies a small complexity penalty based on the number of unique operations in the rule.  Colour validation simulates the full composite chain and only checks colour sufficiency at the final step, so temporary recolouring no longer causes rejection.
+Scoring aggregates similarity metrics and applies a small complexity penalty weighted by the unique operations present in the rule.  Colour validation simulates the full composite chain and only checks colour sufficiency at the final step, so temporary recolouring no longer causes rejection.
 
 ## 4. Scoring System
 `executor/scoring.py` implements the heuristic formula used by `solve_task`:
@@ -24,7 +24,7 @@ Scoring aggregates similarity metrics and applies a small complexity penalty bas
 base = 0.55 * after_pixel + 0.35 * zone_match + 0.1 * shape_bonus
 if after_pixel > before_pixel:
     base += 0.25 * (after_pixel - before_pixel)
-penalty = 0.006 * unique_ops
+penalty = 0.006 * op_cost
 bonus = 0.2 if isinstance(rule, CompositeRule) and base >= 0.95 else 0.0
 final = base - penalty + bonus
 ```

--- a/composite_rules.md
+++ b/composite_rules.md
@@ -24,7 +24,8 @@ Composite rules represent a chain of symbolic transformations executed as a sing
 * **Zone-aware proxy** – `as_symbolic_proxy()` now merges `input_zones` and `output_zones`, fixing dependency misordering for multi-zone composites.【F:arc_solver/src/executor/proxy_ext.py†L40-L57】
 * **Zone chain proxy** – `as_symbolic_proxy()` records `zone_chain` pairs so `sort_rules_by_topology()` can order composites based on zone transitions.【F:arc_solver/src/executor/proxy_ext.py†L41-L91】【F:arc_solver/src/executor/dependency.py†L69-L111】
 * **Color validation update** – composite chains are validated as a whole with colour sufficiency checked only after the final step.【F:arc_solver/src/executor/simulator.py†L212-L340】
-* **Scoring overhaul** – penalties depend only on unique operation types and perfect composites receive a +0.2 bonus.【F:arc_solver/src/executor/scoring.py†L60-L109】
+* **Scoring overhaul** – penalties depend only on unique operation types and perfect composites receive a +0.2 bonus.【F:arc_solver/src/executor/scoring.py†L104-L187】
+* **Composite cost normalisation** – penalty weights are determined per operation type to better balance long chains.【F:arc_solver/src/executor/scoring.py†L82-L187】
 * **Grid growth forecast** – `simulate_composite_safe()` now predicts composite size using `grid_growth_forecast()` and aborts when the limit is exceeded.【F:arc_solver/src/executor/simulator.py†L60-L123】
 * **Training colour lineage** – `validate_color_dependencies` accepts chains when the final colours match the training grid and records transitions via a lineage tracker.
 
@@ -33,7 +34,7 @@ Composite rules represent a chain of symbolic transformations executed as a sing
 * Large grid expansions are validated ahead of time to avoid exceeding safety limits.
 
 ## Planned Mitigations
-* Further normalise cost for composites by weighting cost per unique transformation type.
+* ~~Further normalise cost for composites by weighting cost per unique transformation type.~~ Implemented via `op_cost()` weighting.
 * Relax colour validation when subsequent steps explicitly replace the missing colours.
 * Expand `as_symbolic_proxy()` to include zone information of each step so dependency ordering can reason about spatial scopes.
 * Implemented boundary checks and proactive uncertainty-map resizing when composites grow the grid.

--- a/scoring_system.md
+++ b/scoring_system.md
@@ -8,14 +8,14 @@ The scoring system ranks candidate rules by their expected contribution to solvi
 base = 0.55 * after_pixel + 0.35 * zone_match + 0.1 * shape_bonus
 if after_pixel > before_pixel:
     base += 0.25 * (after_pixel - before_pixel)
-penalty = 0.006 * unique_ops
+penalty = 0.006 * op_cost
 bonus = 0.2 if isinstance(rule, CompositeRule) and base >= 0.95 else 0.0
 final = base - penalty + bonus
 ```
-Lines【F:arc_solver/src/executor/scoring.py†L60-L109】 detail this logic. `after_pixel` is the raw grid match after applying the rule. `zone_match` measures how well labelled zones align, and `shape_bonus` rewards correct output shape. `unique_ops` counts the distinct operation types in the rule.
+Lines【F:arc_solver/src/executor/scoring.py†L82-L187】 detail this logic. `after_pixel` is the raw grid match after applying the rule. `zone_match` measures how well labelled zones align, and `shape_bonus` rewards correct output shape. `op_cost` sums the weighted unique transformation types involved in the rule.
 
 ### 2.1 Penalty Terms
-`unique_ops()` returns the number of distinct transformations used by a rule. This replaces the previous heavy dependence on `rule_cost`.
+`op_cost()` returns the weighted sum of unique transformation types used by a rule. It replaces the previous heavy dependence on `rule_cost` and pure operation counts.
 
 ### 2.2 Composite Bonus
 A composite rule that matches at least 95% similarity receives a `+0.2` bonus.


### PR DESCRIPTION
## Summary
- normalise composite penalty per operation type with `op_cost()`
- add `OP_WEIGHTS` table in scoring
- add integration test using real training task
- document updated scoring logic and patch log entry

## Testing
- `pip install -e .`
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fe3f16b888322aa7eca082d88cb19