### PR TITLE
Add grid visual diff report utility

### DIFF
--- a/arc_solver/src/debug/visualizer.py
+++ b/arc_solver/src/debug/visualizer.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Grid comparison utilities for debugging purposes."""
+
+from typing import List, Optional
+
+from arc_solver.src.core.grid import Grid
+
+
+def visual_diff_report(pred: Grid, target: Grid) -> str:
+    """Return a human-readable report of mismatches between ``pred`` and ``target``.
+
+    The report lists each cell that differs, providing coordinates and color
+    values. At the end a summary of total errors and match ratio is appended.
+    """
+
+    report_lines: List[str] = []
+
+    shape_pred = pred.shape()
+    shape_target = target.shape()
+    if shape_pred != shape_target:
+        report_lines.append(
+            f"Shape mismatch: predicted {shape_pred}, expected {shape_target}"
+        )
+
+    h = max(shape_pred[0], shape_target[0])
+    w = max(shape_pred[1], shape_target[1])
+
+    errors = 0
+    for r in range(h):
+        for c in range(w):
+            a = pred.get(r, c, None)
+            b = target.get(r, c, None)
+            if a == b:
+                continue
+
+            pred_desc = "empty" if a is None else f"color {a}"
+            tgt_desc = "empty" if b is None else f"color {b}"
+
+            zone: Optional[str] = None
+
+            def _zone(sym: Optional[object]) -> Optional[str]:
+                if sym is None:
+                    return None
+                if isinstance(sym, list):
+                    for s in sym:
+                        if getattr(s, "type", None).__str__() == "ZONE":
+                            return str(s.value)
+                    return None
+                if getattr(sym, "type", None).__str__() == "ZONE":
+                    return str(getattr(sym, "value", None))
+                return None
+
+            if pred.overlay or target.overlay:
+                zone = _zone(pred.overlay[r][c] if pred.overlay else None) or _zone(
+                    target.overlay[r][c] if target.overlay else None
+                )
+
+            loc = f"({r},{c})"
+            if zone:
+                loc += f" zone {zone}"
+            report_lines.append(
+                f"Mismatch at {loc}: predicted {pred_desc}, expected {tgt_desc}"
+            )
+            errors += 1
+
+    total_cells = h * w
+    match_ratio = (total_cells - errors) / total_cells if total_cells else 1.0
+    report_lines.append(f"Total errors: {errors}")
+    report_lines.append(f"Match ratio: {match_ratio:.2f}")
+
+    return "\n".join(report_lines)
+
+
+__all__ = ["visual_diff_report"]

--- a/arc_solver/tests/test_debug.py
+++ b/arc_solver/tests/test_debug.py
@@ -1,0 +1,20 @@
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.debug.visualizer import visual_diff_report
+
+
+def test_visual_diff_report_basic():
+    pred = Grid([[1, 2], [3, 4]])
+    target = Grid([[1, 0], [3, 4]])
+    report = visual_diff_report(pred, target)
+    assert "Mismatch at (0,1)" in report
+    assert "predicted color 2" in report
+    assert "expected color 0" in report
+    assert "Total errors: 1" in report
+
+
+def test_visual_diff_report_shape_mismatch():
+    pred = Grid([[1, 2], [3, 4]])
+    target = Grid([[1, 2, 3], [3, 4, 5], [6, 7, 8]])
+    report = visual_diff_report(pred, target)
+    assert "Shape mismatch" in report
+    assert "Total errors: 5" in report


### PR DESCRIPTION
## Summary
- add new debug/visualizer module with `visual_diff_report` to inspect grid mismatches
- include a test validating mismatch reporting and shape mismatch behaviour

## Testing
- `pip install -e .`
- `pytest -q arc_solver/tests/test_debug.py`

------
https://chatgpt.com/codex/tasks/task_e_686fee0675308322bfff1fef4a907ade