### PR TITLE
Implement rule lineage tracking utility

### DIFF
--- a/arc_solver/src/memory/lineage.py
+++ b/arc_solver/src/memory/lineage.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Utility for tracking rule lineage and scoring metadata."""
+
+from typing import Any, Dict, List, Optional
+
+
+class RuleLineageTracker:
+    """Track ancestry and scoring details for symbolic rules."""
+
+    def __init__(self) -> None:
+        self._data: Dict[str, Dict[str, Any]] = {}
+
+    def add_entry(
+        self,
+        rule_id: str,
+        parent_ids: Optional[List[str]] | None = None,
+        *,
+        source_task: Optional[str] = None,
+        scoring_trace: Optional[Dict[str, Any]] = None,
+        **metadata: Any,
+    ) -> None:
+        """Insert or update ``rule_id`` with lineage information."""
+
+        entry = self._data.setdefault(rule_id, {"parents": []})
+        if parent_ids is not None:
+            entry["parents"] = list(parent_ids)
+        if source_task is not None:
+            entry["source"] = source_task
+        if scoring_trace is not None:
+            entry.update(scoring_trace)
+        if metadata:
+            entry.setdefault("meta", {}).update(metadata)
+
+    def export(self) -> Dict[str, Dict[str, Any]]:
+        """Return a JSON serialisable mapping of all tracked rules."""
+
+        result: Dict[str, Dict[str, Any]] = {}
+        for rid, entry in self._data.items():
+            exported: Dict[str, Any] = {"parents": entry.get("parents", [])}
+            if "source" in entry:
+                exported["source"] = entry["source"]
+            if "meta" in entry:
+                exported["meta"] = entry["meta"]
+            for k, v in entry.items():
+                if k in {"parents", "source", "meta"}:
+                    continue
+                exported[k] = v
+            result[rid] = exported
+        return result

--- a/arc_solver/tests/test_memory.py
+++ b/arc_solver/tests/test_memory.py
@@ -1,0 +1,18 @@
+from arc_solver.src.memory.lineage import RuleLineageTracker
+
+
+def test_tracker_creation_and_insertion():
+    tracker = RuleLineageTracker()
+    tracker.add_entry("R1", parent_ids=[], source_task="000")
+    assert tracker.export() == {"R1": {"parents": [], "source": "000"}}
+
+
+def test_export_nested_ancestry():
+    tracker = RuleLineageTracker()
+    tracker.add_entry("R1", source_task="005", scoring_trace={"score": 0.92})
+    tracker.add_entry("R2", parent_ids=["R1"], source_task="005", scoring_trace={"score": 0.77})
+    tracker.add_entry("R3", parent_ids=["R2", "R1"], source_task="005", scoring_trace={"score": 0.85})
+    data = tracker.export()
+    assert data["R3"]["parents"] == ["R2", "R1"]
+    assert data["R3"]["score"] == 0.85
+    assert data["R1"]["score"] == 0.92


### PR DESCRIPTION
## Summary
- add `RuleLineageTracker` for recording rule ancestry and scores
- test lineage tracking export logic

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fee7461808322867cfc1c86824319