### PR TITLE
Add mirror_tile operator

### DIFF
--- a/arc_solver/src/symbolic/operators.py
+++ b/arc_solver/src/symbolic/operators.py
@@ -1,0 +1,50 @@
+"""Standalone symbolic transformation operators."""
+
+from __future__ import annotations
+
+from arc_solver.src.core.grid import Grid
+
+__all__ = ["mirror_tile"]
+
+
+def mirror_tile(grid: Grid, axis: str, count: int) -> Grid:
+    """Return grid tiled ``count`` times while mirroring every other tile.
+
+    Parameters
+    ----------
+    grid:
+        Input :class:`Grid` to tile.
+    axis:
+        ``"horizontal"`` or ``"vertical"``. Determines both the tiling
+        direction and the axis of mirroring.
+    count:
+        Number of tiles to produce. Must be >= 2.
+    """
+
+    if count <= 1:
+        return grid
+
+    axis = axis.lower()
+    if axis not in {"horizontal", "vertical"}:
+        raise ValueError("axis must be 'horizontal' or 'vertical'")
+
+    h, w = grid.shape()
+
+    if axis == "horizontal":
+        new_w = w * count
+        new_data = [[0 for _ in range(new_w)] for _ in range(h)]
+        for idx in range(count):
+            tile = grid.flip_horizontal() if idx % 2 == 1 else grid
+            for r in range(h):
+                for c in range(w):
+                    new_data[r][idx * w + c] = tile.get(r, c)
+    else:  # axis == "vertical"
+        new_h = h * count
+        new_data = [[0 for _ in range(w)] for _ in range(new_h)]
+        for idx in range(count):
+            tile = grid.flip_vertical() if idx % 2 == 1 else grid
+            for r in range(h):
+                for c in range(w):
+                    new_data[idx * h + r][c] = tile.get(r, c)
+
+    return Grid(new_data)

--- a/arc_solver/tests/test_symbolic_ops.py
+++ b/arc_solver/tests/test_symbolic_ops.py
@@ -1,0 +1,13 @@
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic.operators import mirror_tile
+
+
+def test_mirror_tile_horizontal():
+    g = Grid([[1, 2], [3, 4]])
+    out = mirror_tile(g, "horizontal", 3)
+    assert out.shape() == (2, 6)
+    expected = [
+        [1, 2, 2, 1, 1, 2],
+        [3, 4, 4, 3, 3, 4],
+    ]
+    assert out.data == expected


### PR DESCRIPTION
## Summary
- implement `mirror_tile` operator for mirrored tiling
- add tests to cover horizontal mirroring

## Testing
- `pytest -q arc_solver/tests/test_symbolic_ops.py`

------
https://chatgpt.com/codex/tasks/task_e_686fef152b008322b9999a7e5c879522