### PR TITLE
Implement grid color entropy utility

### DIFF
--- a/arc_solver/src/scoring/entropy_utils.py
+++ b/arc_solver/src/scoring/entropy_utils.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Entropy helpers for scoring heuristics."""
+
+from collections import Counter
+from math import log2
+
+from arc_solver.src.core.grid import Grid
+
+
+def grid_color_entropy(grid: Grid) -> float:
+    """Return normalized Shannon entropy of the color distribution in ``grid``.
+
+    Cells with value ``0`` or negative numbers are ignored. The result is
+    scaled by the maximum possible entropy given the number of colors present,
+    yielding a value in the ``[0.0, 1.0]`` range.
+    """
+
+    counts: Counter[int] = Counter()
+    total = 0
+    for row in grid.data:
+        for val in row:
+            if val <= 0:
+                continue
+            counts[val] += 1
+            total += 1
+
+    if total == 0:
+        return 0.0
+
+    n_colors = len(counts)
+    if n_colors <= 1:
+        return 0.0
+
+    entropy = 0.0
+    for c in counts.values():
+        p = c / total
+        entropy -= p * log2(p)
+
+    max_entropy = log2(n_colors)
+    return entropy / max_entropy if max_entropy else 0.0
+
+
+__all__ = ["grid_color_entropy"]

--- a/arc_solver/tests/test_scoring.py
+++ b/arc_solver/tests/test_scoring.py
@@ -8,6 +8,7 @@ from arc_solver.src.symbolic.vocabulary import (
     TransformationNature,
 )
 from arc_solver.src.executor.scoring import score_rule, preferred_rule_types
+from arc_solver.src.scoring.entropy_utils import grid_color_entropy
 import pytest
 
 
@@ -76,3 +77,16 @@ def test_score_rule_expected_value():
     score = score_rule(inp, out, rule)
     assert score == pytest.approx(1.244, rel=1e-3)
 
+
+def test_grid_color_entropy_extremes():
+    same = Grid([[1, 1], [1, 1]])
+    assert grid_color_entropy(same) == 0.0
+
+    uniform = Grid([[1, 2], [3, 4]])
+    assert grid_color_entropy(uniform) == pytest.approx(1.0, rel=1e-6)
+
+
+def test_grid_color_entropy_intermediate():
+    mixed = Grid([[1, 1, 1], [1, 1, 2]])
+    ent = grid_color_entropy(mixed)
+    assert 0.0 < ent < 1.0


### PR DESCRIPTION
## Summary
- add `grid_color_entropy` to compute normalized color entropy
- test the entropy extremes and intermediate cases

## Testing
- `pip install -e .`
- `pip install PyYAML numpy scikit-image matplotlib scikit-learn`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686feed89a788322a294fa5dc3da23a6