### PR TITLE
Implement pattern fill operator

### DIFF
--- a/arc_solver/src/symbolic/__init__.py
+++ b/arc_solver/src/symbolic/__init__.py
@@ -13,6 +13,7 @@ from .repeat_rule import repeat_tile, generate_repeat_rules
 from .composite_rules import generate_repeat_composite_rules
 from .abstraction_dsl import rules_to_program, program_to_rules
 from .program_dsl import parse_program_expression
+from .pattern_fill_operator import pattern_fill
 
 __all__ = [
     "Symbol",
@@ -30,4 +31,5 @@ __all__ = [
     "generate_repeat_rules",
     "generate_repeat_composite_rules",
     "CompositeRule",
+    "pattern_fill",
 ]

--- a/arc_solver/src/symbolic/pattern_fill_operator.py
+++ b/arc_solver/src/symbolic/pattern_fill_operator.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Pattern fill operator for symbolic grid transformations."""
+
+from arc_solver.src.core.grid import Grid
+
+__all__ = ["pattern_fill"]
+
+
+def pattern_fill(grid: Grid, mask: Grid, pattern: Grid) -> Grid:
+    """Return ``grid`` with ``pattern`` tiled over non-zero ``mask`` cells.
+
+    Parameters
+    ----------
+    grid:
+        Base :class:`Grid` to copy before filling.
+    mask:
+        Mask with same shape as ``grid``. Any non-zero cell triggers
+        pattern placement centred on that coordinate.
+    pattern:
+        Tile pattern pasted at each mask location. If placement exceeds
+        grid bounds, it is cropped.
+    """
+
+    if grid.shape() != mask.shape():
+        raise ValueError("grid and mask must have the same shape")
+
+    out = Grid(grid.to_list())
+
+    ph, pw = pattern.shape()
+    h, w = grid.shape()
+    off_r = ph // 2
+    off_c = pw // 2
+
+    for r in range(h):
+        for c in range(w):
+            if mask.get(r, c) == 0:
+                continue
+            start_r = r - off_r
+            start_c = c - off_c
+            for pr in range(ph):
+                for pc in range(pw):
+                    gr = start_r + pr
+                    gc = start_c + pc
+                    if 0 <= gr < h and 0 <= gc < w:
+                        out.set(gr, gc, pattern.get(pr, pc))
+
+    return out

--- a/arc_solver/tests/test_pattern_fill.py
+++ b/arc_solver/tests/test_pattern_fill.py
@@ -1,0 +1,37 @@
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic.pattern_fill_operator import pattern_fill
+
+
+def test_pattern_fill_single():
+    grid = Grid([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+    mask = Grid([[0, 0, 0], [0, 1, 0], [0, 0, 0]])
+    pattern = Grid([[1, 2], [3, 4]])
+
+    out = pattern_fill(grid, mask, pattern)
+
+    assert out.data == [
+        [1, 2, 0],
+        [3, 4, 0],
+        [0, 0, 0],
+    ]
+
+
+def test_pattern_fill_overlap_order():
+    grid = Grid([[0] * 3 for _ in range(3)])
+    mask = Grid(
+        [
+            [0, 0, 0],
+            [0, 1, 1],
+            [0, 0, 0],
+        ]
+    )
+    pattern = Grid([[5, 6], [7, 8]])
+
+    out = pattern_fill(grid, mask, pattern)
+
+    # The second mask cell overwrites overlapping area
+    assert out.data == [
+        [5, 5, 6],
+        [7, 7, 8],
+        [0, 0, 0],
+    ]


### PR DESCRIPTION
## Summary
- add new pattern fill operator for symbolic grids
- export pattern_fill in symbolic package
- test pattern filling with single and overlapping patterns

## Testing
- `pytest arc_solver/tests/test_pattern_fill.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686ff08812e083228933e7136d765c69