### PR TITLE
Add rotate_about_point operator

### DIFF
--- a/arc_solver/src/symbolic/rotate_about_point.py
+++ b/arc_solver/src/symbolic/rotate_about_point.py
@@ -1,0 +1,48 @@
+"""Grid rotation around an arbitrary pivot."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from arc_solver.src.core.grid import Grid
+
+__all__ = ["rotate_about_point"]
+
+
+def rotate_about_point(grid: Grid, center: Tuple[int, int], angle: int) -> Grid:
+    """Return ``grid`` rotated ``angle`` degrees about ``center``.
+
+    Parameters
+    ----------
+    grid:
+        Input :class:`Grid` to rotate.
+    center:
+        (row, col) coordinate about which the grid is rotated.
+    angle:
+        Rotation angle in degrees. Must be one of ``90``, ``180`` or ``270``.
+    """
+
+    if angle not in {90, 180, 270}:
+        raise ValueError("angle must be 90, 180, or 270 degrees")
+
+    h, w = grid.shape()
+    cx, cy = center  # center row and column
+    new_data = [[0 for _ in range(w)] for _ in range(h)]
+
+    for r in range(h):
+        for c in range(w):
+            val = grid.get(r, c)
+            if angle == 90:
+                nr = cx - (c - cy)
+                nc = cy + (r - cx)
+            elif angle == 180:
+                nr = 2 * cx - r
+                nc = 2 * cy - c
+            else:  # angle == 270
+                nr = cx + (c - cy)
+                nc = cy - (r - cx)
+
+            if 0 <= nr < h and 0 <= nc < w:
+                new_data[nr][nc] = val
+
+    return Grid(new_data)

--- a/arc_solver/tests/test_rotate_about_point.py
+++ b/arc_solver/tests/test_rotate_about_point.py
@@ -1,0 +1,50 @@
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic.rotate_about_point import rotate_about_point
+
+
+def test_rotate_l_90():
+    grid = Grid([
+        [1, 0, 0],
+        [1, 0, 0],
+        [1, 1, 0],
+    ])
+    center = (1, 1)
+    out = rotate_about_point(grid, center, 90)
+    expected = [
+        [0, 0, 0],
+        [0, 0, 1],
+        [1, 1, 1],
+    ]
+    assert out.data == expected
+
+
+def test_rotate_t_180():
+    grid = Grid([
+        [0, 1, 0],
+        [1, 1, 1],
+        [0, 0, 0],
+    ])
+    center = (1, 1)
+    out = rotate_about_point(grid, center, 180)
+    expected = [
+        [0, 0, 0],
+        [1, 1, 1],
+        [0, 1, 0],
+    ]
+    assert out.data == expected
+
+
+def test_rotate_l_270():
+    grid = Grid([
+        [1, 0, 0],
+        [1, 0, 0],
+        [1, 1, 0],
+    ])
+    center = (1, 1)
+    out = rotate_about_point(grid, center, 270)
+    expected = [
+        [1, 1, 1],
+        [1, 0, 0],
+        [0, 0, 0],
+    ]
+    assert out.data == expected


### PR DESCRIPTION
## Summary
- implement `rotate_about_point` utility for Grid rotation around an arbitrary pivot
- test 90/180/270 rotations with asymmetric shapes

## Testing
- `pytest -q arc_solver/tests/test_symbolic_ops.py arc_solver/tests/test_rotate_about_point.py`

------
https://chatgpt.com/codex/tasks/task_e_686ff0d197b48322bbf4b553641eb8ea