### PR TITLE
Implement lineage tracker utility

### DIFF
--- a/arc_solver/src/memory/__init__.py
+++ b/arc_solver/src/memory/__init__.py
@@ -1,20 +1,35 @@
 """Memory utilities for storing symbolic policies."""
 
 from .policy_cache import PolicyCache
-from .memory_store import (
-    save_rule_program,
-    load_memory,
-    retrieve_similar_signatures,
-    match_signature,
-    get_best_memory_match,
-    extract_task_constraints,
-    get_last_load_stats,
-    update_memory_stats,
-    preload_memory_from_kaggle_input,
-)
+from .lineage import LineageTracker, RuleLineageTracker
+
+try:  # Optional import; memory_store depends on heavy packages like sklearn
+    from .memory_store import (
+        save_rule_program,
+        load_memory,
+        retrieve_similar_signatures,
+        match_signature,
+        get_best_memory_match,
+        extract_task_constraints,
+        get_last_load_stats,
+        update_memory_stats,
+        preload_memory_from_kaggle_input,
+    )
+except Exception:  # pragma: no cover - optional dependency missing
+    save_rule_program = None
+    load_memory = None
+    retrieve_similar_signatures = None
+    match_signature = None
+    get_best_memory_match = None
+    extract_task_constraints = None
+    get_last_load_stats = None
+    update_memory_stats = None
+    preload_memory_from_kaggle_input = None
 
 __all__ = [
     "PolicyCache",
+    "LineageTracker",
+    "RuleLineageTracker",
     "save_rule_program",
     "load_memory",
     "retrieve_similar_signatures",


### PR DESCRIPTION
## Summary
- add flexible `LineageTracker` class for recording rule evolution
- export lineage utilities from memory package
- avoid hard dependency on heavy `memory_store` when importing memory

## Testing
- `pip install -e .`
- `pytest arc_solver/tests/test_memory.py -q`
- `python - <<'EOF'
from arc_solver.src.memory.lineage import LineageTracker
tracker = LineageTracker()
tracker.add_step("r1", "start", [[1]])
tracker.add_step("r1", "end", [[2]])
print(tracker.get_lineage("r1"))
EOF`


------
https://chatgpt.com/codex/tasks/task_e_686ff3032fc8832291d9677d27094360