### PR TITLE
Add DSL operator documentation generator

### DIFF
--- a/docs/dsl_autogen_doc.py
+++ b/docs/dsl_autogen_doc.py
@@ -1,0 +1,62 @@
+import inspect
+import pkgutil
+import importlib
+from pathlib import Path
+import sys
+
+# Ensure project root is on the module search path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from arc_solver.src.symbolic import vocabulary
+
+
+def _discover_symbolic_modules():
+    pkg = importlib.import_module("arc_solver.src.symbolic")
+    modules = {}
+    for _, name, _ in pkgutil.iter_modules(pkg.__path__):
+        try:
+            modules[name] = importlib.import_module(f"{pkg.__name__}.{name}")
+        except Exception:
+            continue
+    return modules
+
+
+def _find_operator_info(name: str, modules: dict):
+    op_lower = name.lower()
+    for module in modules.values():
+        for attr_name, obj in inspect.getmembers(module, inspect.isfunction):
+            if obj.__module__ != module.__name__:
+                continue
+            if op_lower in attr_name:
+                doc = inspect.getdoc(obj)
+                sig = str(inspect.signature(obj))
+                return obj.__name__ + sig, (doc.splitlines()[0] if doc else None)
+    return None, None
+
+
+def generate_dsl_docs(output_path: str = "docs/generated_dsl_operators.md") -> None:
+    """Generate Markdown documentation for available DSL operators."""
+
+    modules = _discover_symbolic_modules()
+    lines = ["# Symbolic DSL Operators", ""]
+
+    for op in vocabulary.TransformationType:
+        syntax, desc = _find_operator_info(op.name, modules)
+        if syntax is None:
+            syntax = f"{op.name}(...)"
+        if not desc:
+            desc = "TODO: add description."
+        lines.append(f"## {op.name}\n")
+        lines.append(f"**Syntax:** `{syntax}`\n")
+        lines.append(f"**Description:** {desc}\n")
+        lines.append("**Example:**\n")
+        lines.append("```python\n# Example coming soon\n```\n")
+
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(output_path).write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    generate_dsl_docs()

--- a/docs/generated_dsl_operators.md
+++ b/docs/generated_dsl_operators.md
@@ -1,0 +1,157 @@
+# Symbolic DSL Operators
+
+## REPLACE
+
+**Syntax:** `REPLACE(...)`
+
+**Description:** TODO: add description.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## TRANSLATE
+
+**Syntax:** `TRANSLATE(...)`
+
+**Description:** TODO: add description.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## MERGE
+
+**Syntax:** `MERGE(...)`
+
+**Description:** TODO: add description.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## FILTER
+
+**Syntax:** `FILTER(...)`
+
+**Description:** TODO: add description.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## ROTATE
+
+**Syntax:** `rotate_about_point(grid: 'Grid', center: 'Tuple[int, int]', angle: 'int') -> 'Grid'`
+
+**Description:** Return ``grid`` rotated ``angle`` degrees about ``center``.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## ROTATE90
+
+**Syntax:** `ROTATE90(...)`
+
+**Description:** TODO: add description.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## REFLECT
+
+**Syntax:** `REFLECT(...)`
+
+**Description:** TODO: add description.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## REPEAT
+
+**Syntax:** `generate_repeat_composite_rules(input_grid: 'Grid', output_grid: 'Grid') -> 'List[CompositeRule]'`
+
+**Description:** Return composite rules repeating ``input_grid`` then recolouring to match ``output_grid``.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## SHAPE_ABSTRACT
+
+**Syntax:** `SHAPE_ABSTRACT(...)`
+
+**Description:** TODO: add description.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## CONDITIONAL
+
+**Syntax:** `CONDITIONAL(...)`
+
+**Description:** TODO: add description.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## REGION
+
+**Syntax:** `REGION(...)`
+
+**Description:** TODO: add description.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## FUNCTIONAL
+
+**Syntax:** `FUNCTIONAL(...)`
+
+**Description:** TODO: add description.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## COMPOSITE
+
+**Syntax:** `generate_repeat_composite_rules(input_grid: 'Grid', output_grid: 'Grid') -> 'List[CompositeRule]'`
+
+**Description:** Return composite rules repeating ``input_grid`` then recolouring to match ``output_grid``.
+
+**Example:**
+
+```python
+# Example coming soon
+```


### PR DESCRIPTION
## Summary
- create standalone script `docs/dsl_autogen_doc.py`
- auto-generate `docs/generated_dsl_operators.md` listing DSL operators

## Testing
- `python docs/dsl_autogen_doc.py`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'arc_solver')*

------
https://chatgpt.com/codex/tasks/task_e_686ff3a9c0788322a2649fb79062729d