### PR TITLE
Add zone_remap operator

### DIFF
--- a/arc_solver/src/symbolic/__init__.py
+++ b/arc_solver/src/symbolic/__init__.py
@@ -14,6 +14,7 @@ from .composite_rules import generate_repeat_composite_rules
 from .abstraction_dsl import rules_to_program, program_to_rules
 from .program_dsl import parse_program_expression
 from .pattern_fill_operator import pattern_fill
+from .zone_remap import zone_remap
 
 __all__ = [
     "Symbol",
@@ -32,4 +33,5 @@ __all__ = [
     "generate_repeat_composite_rules",
     "CompositeRule",
     "pattern_fill",
+    "zone_remap",
 ]

--- a/arc_solver/src/symbolic/vocabulary.py
+++ b/arc_solver/src/symbolic/vocabulary.py
@@ -32,6 +32,11 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     rotate_about_point = None  # type: ignore
 
+try:
+    from .zone_remap import zone_remap
+except Exception:  # pragma: no cover - optional dependency
+    zone_remap = None  # type: ignore
+
 MAX_COLOR = 10
 
 
@@ -310,6 +315,21 @@ EXTENDED_OPERATORS: Dict[str, Dict[str, Any]] = {
             nature=TransformationNature.SPATIAL,
         ),
         "desc": "Rotate the grid around a pivot point.",
+    },
+    # Recolour segments based on zone IDs
+    "zone_remap": {
+        "factory": zone_remap,
+        "rule": lambda overlay, mapping: SymbolicRule(
+            transformation=Transformation(
+                TransformationType.FUNCTIONAL,
+                params={"op": "zone_remap"},
+            ),
+            source=[Symbol(SymbolType.REGION, "All")],
+            target=[Symbol(SymbolType.REGION, "All")],
+            nature=TransformationNature.SPATIAL,
+            meta={"mapping": mapping},
+        ),
+        "desc": "Remap colours of zones via an overlay mapping.",
     },
     # Placeholder for future operators
 }

--- a/tests/test_zone_remap.py
+++ b/tests/test_zone_remap.py
@@ -1,0 +1,21 @@
+from arc_solver.src.symbolic.zone_remap import zone_remap
+
+zone_remap_cases = {}
+
+base = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+overlay = [[1, 1, 2], [1, 2, 2], [1, 2, 2]]
+mapping = {1: 3, 2: 5}
+expected = [[3, 3, 5], [3, 5, 5], [3, 5, 5]]
+
+result = zone_remap(base, overlay, mapping)
+assert result == expected
+zone_remap_cases["basic"] = {
+    "grid": base,
+    "overlay": overlay,
+    "mapping": mapping,
+    "expected": expected,
+}
+
+if __name__ == "__main__":
+    from pprint import pprint
+    pprint(zone_remap_cases)


### PR DESCRIPTION
## Summary
- expose `zone_remap` from the symbolic package
- support a new `zone_remap` operator in the vocabulary
- basic regression test for `zone_remap`

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest tests/test_zone_remap.py -q`
- `pytest tests/test_mutation.py tests/test_pattern_fill.py tests/test_rotate_about_point.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68700e4479f48322af3b7c06dcbed810