### PR TITLE
Add shape heuristics for morphological and line operations

### DIFF
--- a/arc_solver/src/executor/simulator.py
+++ b/arc_solver/src/executor/simulator.py
@@ -47,6 +47,7 @@ except Exception:  # pragma: no cover - optional dependency
     dilate_zone = erode_zone = None  # type: ignore
 from arc_solver.src.symbolic.zone_remap import zone_remap
 from arc_solver.src.symbolic.rotate_about_point import rotate_about_point
+from arc_solver.src.segment.segmenter import label_connected_regions, zone_overlay
 
 
 logger = get_logger(__name__)
@@ -867,8 +868,10 @@ def _apply_functional(
             except Exception:
                 zone_id = zone_val
             try:
+                overlay = label_connected_regions(grid)
                 logger.debug("dilate_zone id=%s", zone_id)
-                return dilate_zone(grid, zone_id)
+                new = dilate_zone(grid.to_list(), zone_id, overlay)
+                return Grid(new if isinstance(new, list) else new.tolist())
             except Exception as exc:
                 raise RuleExecutionError(rule, str(exc)) from exc
 
@@ -879,8 +882,10 @@ def _apply_functional(
             except Exception:
                 zone_id = zone_val
             try:
+                overlay = label_connected_regions(grid)
                 logger.debug("erode_zone id=%s", zone_id)
-                return erode_zone(grid, zone_id)
+                new = erode_zone(grid.to_list(), zone_id, overlay)
+                return Grid(new if isinstance(new, list) else new.tolist())
             except Exception as exc:
                 raise RuleExecutionError(rule, str(exc)) from exc
 

--- a/arc_solver/tests/test_shape_based_heuristics.py
+++ b/arc_solver/tests/test_shape_based_heuristics.py
@@ -1,0 +1,70 @@
+from arc_solver.src.abstractions.abstractor import extract_shape_based_rules
+from arc_solver.src.core.grid import Grid
+
+
+def _has_op(rules, op):
+    return any(r.transformation.params.get("op") == op for r in rules)
+
+
+def test_dilate_zone_detection():
+    inp = Grid([
+        [0,0,0],
+        [0,1,0],
+        [0,0,0],
+    ])
+    out = Grid([
+        [0,1,0],
+        [1,1,1],
+        [0,1,0],
+    ])
+    rules = extract_shape_based_rules(inp, out)
+    assert _has_op(rules, "dilate_zone")
+
+
+def test_erode_zone_detection():
+    inp = Grid([
+        [0,0,0,0,0],
+        [0,1,1,1,0],
+        [0,1,1,1,0],
+        [0,1,1,1,0],
+        [0,0,0,0,0],
+    ])
+    out = Grid([
+        [0,0,0,0,0],
+        [0,0,0,0,0],
+        [0,0,1,0,0],
+        [0,0,0,0,0],
+        [0,0,0,0,0],
+    ])
+    rules = extract_shape_based_rules(inp, out)
+    assert _has_op(rules, "erode_zone") or _has_op(rules, "dilate_zone")
+
+
+def test_draw_line_detection():
+    inp = Grid([
+        [1,0,0],
+        [0,0,0],
+        [0,0,1],
+    ])
+    out = Grid([
+        [1,0,0],
+        [1,1,0],
+        [0,1,1],
+    ])
+    rules = extract_shape_based_rules(inp, out)
+    assert _has_op(rules, "draw_line")
+
+
+def test_rotate_patch_detection():
+    inp = Grid([
+        [1,0,0],
+        [1,0,0],
+        [1,1,0],
+    ])
+    out = Grid([
+        [0,0,0],
+        [0,0,1],
+        [1,1,1],
+    ])
+    rules = extract_shape_based_rules(inp, out)
+    assert _has_op(rules, "rotate_about_point") or any(r.transformation.ttype.name == "ROTATE" for r in rules)


### PR DESCRIPTION
## Summary
- import additional helper modules for morphological reasoning
- detect dilate/erode, line drawing and point rotation in shape-based abstraction
- route new heuristics through simulator with zone overlays
- add regression tests for the new heuristics

## Testing
- `pytest arc_solver/tests/test_shape_based_heuristics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687012eb84608322a04dab7a1b6195be