### PR TITLE
Enhance functional rule ranking & metadata dedup

### DIFF
--- a/arc_solver/tests/test_duplicate_removal.py
+++ b/arc_solver/tests/test_duplicate_removal.py
@@ -6,6 +6,7 @@ from arc_solver.src.symbolic.vocabulary import (
     Transformation,
     TransformationType,
 )
+from arc_solver.src.core.grid import Grid
 
 
 def _rule():
@@ -21,3 +22,23 @@ def test_duplicate_removal():
     r2 = _rule()
     dedup = remove_duplicate_rules([r1, r2])
     assert len(dedup) == 1
+
+
+def test_duplicate_removal_with_meta():
+    grid_a = Grid([[1]])
+    grid_b = Grid([[2]])
+    r1 = SymbolicRule(
+        Transformation(TransformationType.FUNCTIONAL, params={"op": "pattern_fill"}),
+        source=[Symbol(SymbolType.REGION, "All")],
+        target=[Symbol(SymbolType.REGION, "All")],
+        meta={"mask": grid_a, "pattern": grid_b},
+    )
+    r2 = SymbolicRule(
+        Transformation(TransformationType.FUNCTIONAL, params={"op": "pattern_fill"}),
+        source=[Symbol(SymbolType.REGION, "All")],
+        target=[Symbol(SymbolType.REGION, "All")],
+        meta={"mask": grid_b, "pattern": grid_b},
+    )
+
+    dedup = remove_duplicate_rules([r1, r2])
+    assert len(dedup) == 2

--- a/arc_solver/tests/test_rule_minimality.py
+++ b/arc_solver/tests/test_rule_minimality.py
@@ -1,4 +1,5 @@
 from arc_solver.src.abstractions.rule_generator import rule_cost
+from arc_solver.src.executor.scoring import _op_cost
 from arc_solver.src.symbolic.vocabulary import (
     SymbolicRule,
     Symbol,
@@ -6,6 +7,7 @@ from arc_solver.src.symbolic.vocabulary import (
     Transformation,
     TransformationType,
 )
+from arc_solver.src.utils import config_loader
 
 
 def test_rule_minimality():
@@ -21,3 +23,16 @@ def test_rule_minimality():
         condition={"zone": "A"},
     )
     assert rule_cost(simple) < rule_cost(complex_rule)
+
+
+def test_rule_cost_functional_sparse():
+    rule = SymbolicRule(
+        Transformation(TransformationType.FUNCTIONAL, params={"op": "dilate_zone"}),
+        source=[Symbol(SymbolType.REGION, "All")],
+        target=[Symbol(SymbolType.REGION, "All")],
+    )
+    config_loader.set_sparse_mode(True)
+    try:
+        assert rule_cost(rule) == _op_cost(rule)
+    finally:
+        config_loader.set_sparse_mode(False)


### PR DESCRIPTION
## Summary
- compute rule cost for functional operations via `_op_cost` when sparse ranking is enabled
- include rule metadata in deduplication
- ensure metadata-aware dedup keeps distinct functional rules
- add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6870167455848322ba13d9e155d0264e