### PR TITLE
Improve generalization using mutation module

### DIFF
--- a/arc_solver/src/meta_generalizer.py
+++ b/arc_solver/src/meta_generalizer.py
@@ -2,29 +2,23 @@ from __future__ import annotations
 
 """Simple rule program generalization utilities."""
 
-from typing import List
+from typing import List, Union
 
-from arc_solver.src.symbolic.vocabulary import SymbolicRule, Symbol, SymbolType
-from arc_solver.src.symbolic.vocabulary import TransformationType
-
-
-def mutate_rule(rule: SymbolicRule, task_signature: str | None = None) -> SymbolicRule:
-    """Return a lightly generalized variant of ``rule``."""
-    if rule.transformation.ttype is TransformationType.REPLACE and rule.source:
-        src = rule.source[0]
-        tgt = rule.target[0] if rule.target else src
-        # drop explicit source color to generalize
-        return SymbolicRule(rule.transformation, source=[], target=[tgt], nature=rule.nature, condition=rule.condition.copy())
-    return rule
+from arc_solver.src.symbolic.vocabulary import SymbolicRule
+from arc_solver.src.symbolic.rule_language import CompositeRule
+from arc_solver.src.symbolic.mutation import mutate_rule
 
 
-def generalize_rule_program(rules: List[SymbolicRule], task_signature: str | None = None) -> List[SymbolicRule]:
-    """Return a list containing original and generalized rules."""
-    out: List[SymbolicRule] = []
+def generalize_rule_program(
+    rules: List[SymbolicRule], task_signature: str | None = None
+) -> List[Union[SymbolicRule, CompositeRule]]:
+    """Return ``rules`` augmented with mutated variants."""
+
+    out: List[Union[SymbolicRule, CompositeRule]] = []
     for r in rules:
         out.append(r)
         try:
-            out.append(mutate_rule(r, task_signature))
+            out.extend(mutate_rule(r))
         except Exception:
             continue
     return out

--- a/arc_solver/tests/test_deep_prior.py
+++ b/arc_solver/tests/test_deep_prior.py
@@ -34,7 +34,7 @@ def test_generalize_rule_program():
     from arc_solver.src.core.grid import Grid
     rule = parse_rule("REPLACE [COLOR=0] -> [COLOR=1]")
     gens = generalize_rule_program([rule])
-    assert gens and len(gens) == 2
+    assert gens and len(gens) >= 2
     simulate_rules(Grid([[0]]), gens)
 
 


### PR DESCRIPTION
## Summary
- import `mutate_rule` from `symbolic.mutation`
- build richer rule programs by calling the mutation utility
- relax generalization test to expect variable rule counts

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687018ef6f5c8322a27db387bcc33411