### PR TITLE
Adjust functional op cost

### DIFF
--- a/arc_solver/src/executor/scoring.py
+++ b/arc_solver/src/executor/scoring.py
@@ -47,7 +47,10 @@ OP_WEIGHTS: Dict[TransformationType, float] = {
     TransformationType.SHAPE_ABSTRACT: 1.3,
     TransformationType.CONDITIONAL: 1.2,
     TransformationType.REGION: 1.1,
-    TransformationType.FUNCTIONAL: 1.3,
+    # Slightly penalise heavy functional operators such as pattern_fill or
+    # morphology-based zone expansion.  These tend to produce large diffs and
+    # should have a higher cost than basic logical transformations.
+    TransformationType.FUNCTIONAL: 1.4,
     TransformationType.COMPOSITE: 1.0,
 }
 

--- a/arc_solver/tests/test_scoring.py
+++ b/arc_solver/tests/test_scoring.py
@@ -90,3 +90,17 @@ def test_grid_color_entropy_intermediate():
     mixed = Grid([[1, 1, 1], [1, 1, 2]])
     ent = grid_color_entropy(mixed)
     assert 0.0 < ent < 1.0
+
+
+def test_functional_weight_penalty():
+    """_op_cost should reflect the increased weight for FUNCTIONAL ops."""
+    rule = SymbolicRule(
+        transformation=Transformation(
+            TransformationType.FUNCTIONAL, params={"op": "pattern_fill"}
+        ),
+        source=[Symbol(SymbolType.REGION, "All")],
+        target=[Symbol(SymbolType.REGION, "All")],
+    )
+    from arc_solver.src.executor.scoring import _op_cost
+
+    assert _op_cost(rule) == pytest.approx(1.4, rel=1e-6)


### PR DESCRIPTION
## Summary
- give FUNCTIONAL ops a higher penalty weight
- check that op_cost reflects new FUNCTIONAL weight

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68701af81948832289d59bcef0d549e0