### PR TITLE
Add CLI trace visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,30 @@ python instrument.py --bundle arc-agi_training_challenges.json --task_id 0000000
 Predicted grids for datasets are written to `submission.json`.  When `solve_task` runs with `debug=True` a detailed log file is created under `logs/` describing extracted rules, conflicts and scoring statistics.  Failures below a score threshold are appended to `logs/failure_log.jsonl` as JSON lines containing `intermediate_grids`, `color_lineage`, `rejection_stage` and, when score tracing is enabled, a `score_trace` breakdown.
 Fallback predictions are now skipped when a candidate rule exactly matches the target (`similarity==1.0`).  If such a rule exists but cannot be executed the fallback entry is tagged with `reason: high_cost_valid_rule` in the log.  When invoked the fallback predictor first applies the most common rotation or mirror operation observed in the training set before padding the grid with the dominant colour.  If composite rules fail outright the solver falls back to a simpler rule pipeline instead of immediately padding.
 
-## 7. Example Tasks & Visualizations
+## 7. Debug and Instrumentation Flow
+
+When ``solve_task`` is executed with ``debug=True`` the solver writes verbose
+trace entries under ``logs/``. These include scoring information and the
+predicted grids. The ``trace_visualizer`` tool can convert such a trace into a
+PDF highlighting mismatched zones and overlaying the best prediction.
+
+```bash
+trace_visualizer --task_id 00000001 \
+                 --trace_file logs/trace.jsonl \
+                 --task_file arc-agi_training_challenges.json \
+                 --solution_file arc-agi_training_solutions.json
+```
+
+## 8. Example Tasks & Visualizations
 
 Sample notebooks in [`arc_solver/notebooks`](arc_solver/notebooks) demonstrate zone overlays and trace debugging.  The `docs/` folder contains architecture diagrams.  Generated visualisations and experiment outputs are stored under `arc_solver/experiments`.
 
-## 8. Known Issues / Future Work
+## 9. Known Issues / Future Work
 
 * Conflict marking resizes the uncertainty grid to avoid `IndexError` when rules expand the working grid. `simulate_composite_safe()` forecasts growth beforehand to keep grids under `64x64`.
 * Some advanced scoring functions are placeholders (`TODO` in comments) and require tuning.
 
-## 9. Developer Notes
+## 10. Developer Notes
 
 * Run `pytest` before submitting changes.  All current tests should pass (142 tests)【69a983†L1-L4】.
 * GitHub Actions CI validates the same 142 tests on every push.

--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,9 @@ setup(
     name="arc_solver",
     version="0.1.0",
     packages=find_packages(),
+    entry_points={
+        "console_scripts": [
+            "trace_visualizer=tools.trace_visualizer:main",
+        ]
+    },
 )

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""CLI tools for debugging."""

--- a/tools/trace_visualizer.py
+++ b/tools/trace_visualizer.py
@@ -3,6 +3,15 @@
 This utility loads a JSON lines trace file produced when score tracing is
 enabled and renders a diagnostic figure with prediction overlays and rule
 breakdowns.  It is primarily meant to help debugging failed rules.
+
+Usage once installed with ``pip``:
+
+```
+trace_visualizer --task_id 00000001 \
+                 --trace_file logs/trace.jsonl \
+                 --task_file arc-agi_training_challenges.json \
+                 --solution_file arc-agi_training_solutions.json
+```
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- document the new `trace_visualizer` tool in the README
- expose `trace_visualizer` as a console script via setup.py
- add minimal `tools` package for distribution
- include usage instructions in the trace visualizer module

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68701b043e9083229f255077c68db40d