### PR TITLE
Improve rule dedup and cost handling

### DIFF
--- a/arc_solver/tests/test_rule_generalization.py
+++ b/arc_solver/tests/test_rule_generalization.py
@@ -20,3 +20,21 @@ def test_generalize_rules_with_composite():
     config_loader.set_sparse_mode(False)
     assert rules == [comp]
 
+
+def test_generalize_rules_preserves_functional_metadata():
+    r1 = SymbolicRule(
+        Transformation(TransformationType.FUNCTIONAL, params={"op": "dilate_zone"}),
+        source=[Symbol(SymbolType.REGION, "All")],
+        target=[Symbol(SymbolType.REGION, "All")],
+    )
+    r2 = SymbolicRule(
+        Transformation(TransformationType.FUNCTIONAL, params={"op": "erode_zone"}),
+        source=[Symbol(SymbolType.REGION, "All")],
+        target=[Symbol(SymbolType.REGION, "All")],
+    )
+
+    rules = generalize_rules([r1, r2])
+    assert len(rules) == 2
+    assert rules[0].meta.get("op") == "dilate_zone"
+    assert rules[1].meta.get("op") == "erode_zone"
+


### PR DESCRIPTION
## Summary
- preserve operator name metadata when generalizing rules so deduplication can distinguish functional ops
- test that functional metadata is kept

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871edc6d5fc832286343942d6f5e077