### PR TITLE
Extend DSL parsing for new functional operators

### DIFF
--- a/arc_solver/src/symbolic/rule_language.py
+++ b/arc_solver/src/symbolic/rule_language.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import List, Dict, Any, Optional
 from dataclasses import dataclass, field
 import logging
+import ast
 
 from .vocabulary import (
     Symbol,
@@ -58,7 +59,15 @@ def validate_dsl_program(program_str: str) -> bool:
     if any(tok in program_str for tok in ["NaN", "None"]):
         return False
     op = clean_dsl_string(program_str).split("[", 1)[0].strip()
-    if op.upper() not in {t.name for t in TransformationType}:
+    base_op = op.split("(", 1)[0]
+    if base_op.upper() not in {t.name for t in TransformationType} and base_op.lower() not in {
+        "mirror_tile",
+        "pattern_fill",
+        "rotate_about_point",
+        "zone_remap",
+        "dilate_zone",
+        "erode_zone",
+    }:
         return False
     return True
 
@@ -107,27 +116,173 @@ def _parse_symbol_list(text: str) -> List[Symbol]:
 
 
 def parse_rule(text: str) -> SymbolicRule:
+    """Parse ``text`` into a :class:`SymbolicRule` instance.
+
+    The parser understands optional transformation parameters using a
+    ``NAME(key=value, ...)`` syntax.  Unknown operators fall back to the
+    ``FUNCTIONAL`` transformation type with ``op`` capturing the raw
+    operator name.  This keeps older DSL strings compatible while
+    allowing new functional primitives to round trip correctly.
+    """
+
     text = clean_dsl_string(text)
     if not validate_dsl_program(text):
         raise ValueError("Malformed rule expression")
-    if " " not in text:
+    if "[" not in text or "]" not in text:
         raise ValueError("Invalid rule format")
-    op, remainder = text.split(" ", 1)
-    try:
-        ttype = TransformationType[op.upper()]
-    except KeyError as exc:
-        raise ValueError(f"Unknown transformation type: {op}") from exc
+
+    idx = text.index("[")
+    op_token = text[:idx].strip()
+    remainder = text[idx:].lstrip()
+
+    params: Dict[str, Any] = {}
+    if op_token.endswith(")") and "(" in op_token:
+        op_name, param_str = op_token.split("(", 1)
+        op_name = op_name.strip()
+        param_str = param_str[:-1]
+        for part in param_str.split(","):
+            part = part.strip()
+            if not part:
+                continue
+            if "=" not in part:
+                logger.warning("Malformed parameter '%s' in '%s'", part, text)
+                continue
+            k, v = [p.strip() for p in part.split("=", 1)]
+            params[k] = v
+    else:
+        op_name = op_token.strip()
+
+    ttype: TransformationType
+    meta: Dict[str, Any] = {}
+    lower_op = op_name.lower()
+    if op_name.upper() in TransformationType.__members__:
+        ttype = TransformationType[op_name.upper()]
+    elif lower_op == "rotate_about_point":
+        ttype = TransformationType.ROTATE
+        pivot = params.pop("pivot", None)
+        if pivot is not None:
+            try:
+                cx, cy = [p.strip() for p in str(pivot).strip("() ").split(",")]
+                params["cx"] = cx
+                params["cy"] = cy
+            except Exception:
+                logger.warning("Malformed pivot parameter: %s", pivot)
+        angle = params.pop("angle", None)
+        if angle is not None:
+            params["angle"] = angle
+    elif lower_op in {"mirror_tile", "pattern_fill", "zone_remap", "dilate_zone", "erode_zone"}:
+        ttype = TransformationType.FUNCTIONAL
+        params = {**{k: v for k, v in params.items() if v is not None}, "op": lower_op, **{}}
+        if lower_op in {"dilate_zone", "erode_zone"}:
+            z = params.pop("zone_id", None)
+            if z is not None:
+                params["zone"] = z
+        if lower_op == "zone_remap":
+            mapping = params.pop("mapping", None)
+            if mapping is not None:
+                try:
+                    meta["mapping"] = ast.literal_eval(mapping)
+                except Exception:
+                    logger.warning("Failed to parse mapping: %s", mapping)
+                    meta["mapping"] = mapping
+        if lower_op == "pattern_fill":
+            mapping = params.pop("mapping", None)
+            if mapping is not None:
+                try:
+                    meta["mapping"] = ast.literal_eval(mapping)
+                except Exception:
+                    meta["mapping"] = mapping
+    else:
+        raise ValueError(f"Unknown transformation type: {op_name}")
+
     if "->" not in remainder:
         raise ValueError("Rule must contain '->'")
+
     left_str, right_str = [part.strip() for part in remainder.split("->", 1)]
     left_syms = _parse_symbol_list(left_str)
     right_syms = _parse_symbol_list(right_str)
-    transformation = Transformation(ttype)
-    return SymbolicRule(transformation=transformation, source=left_syms, target=right_syms)
+
+    transformation = Transformation(ttype, params={k: str(v) for k, v in params.items()})
+    return SymbolicRule(transformation=transformation, source=left_syms, target=right_syms, meta=meta)
 
 
 def rule_to_dsl(rule: SymbolicRule) -> str:
-    return str(rule)
+    """Serialise ``rule`` back into DSL form including parameters."""
+
+    op_name = rule.transformation.ttype.value
+    params = dict(rule.transformation.params)
+
+    # Detect functional shorthand operators
+    functional_op = None
+    if rule.transformation.ttype is TransformationType.FUNCTIONAL:
+        functional_op = params.get("op")
+    if rule.transformation.ttype is TransformationType.ROTATE and {
+        "cx",
+        "cy",
+        "angle",
+    }.issubset(params):
+        functional_op = "rotate_about_point"
+
+    param_parts: list[str] = []
+
+    if functional_op == "mirror_tile":
+        op_name = "mirror_tile"
+        axis = params.get("axis")
+        repeats = params.get("repeats")
+        if axis is not None:
+            param_parts.append(f"axis={axis}")
+        if repeats is not None:
+            param_parts.append(f"repeats={repeats}")
+    elif functional_op == "pattern_fill":
+        op_name = "pattern_fill"
+        mapping = rule.meta.get("mapping") or params.get("mapping")
+        if mapping is not None:
+            if isinstance(mapping, dict):
+                items = ", ".join(f"{k}: {v}" for k, v in sorted(mapping.items()))
+                mapping_str = "{" + items + "}"
+            else:
+                mapping_str = str(mapping)
+            param_parts.append(f"mapping={mapping_str}")
+    elif functional_op == "zone_remap":
+        op_name = "zone_remap"
+        mapping = rule.meta.get("mapping") or params.get("mapping")
+        if mapping is not None:
+            if isinstance(mapping, dict):
+                items = ", ".join(f"{k}: {v}" for k, v in sorted(mapping.items()))
+                mapping_str = "{" + items + "}"
+            else:
+                mapping_str = str(mapping)
+            param_parts.append(f"mapping={mapping_str}")
+    elif functional_op in {"dilate_zone", "erode_zone"}:
+        op_name = functional_op
+        zone = params.get("zone") or params.get("zone_id")
+        if zone is not None:
+            param_parts.append(f"zone_id={zone}")
+    elif functional_op:
+        param_parts = [f"{k}={v}" for k, v in params.items() if k != "op"]
+        op_name = functional_op
+    elif functional_op is None and rule.transformation.ttype is TransformationType.ROTATE:
+        cx = params.get("cx")
+        cy = params.get("cy")
+        angle = params.get("angle")
+        op_name = "rotate_about_point"
+        if cx is not None and cy is not None:
+            param_parts.append(f"pivot=({cx},{cy})")
+        if angle is not None:
+            param_parts.append(f"angle={angle}")
+    else:
+        param_parts = [f"{k}={v}" for k, v in params.items()]
+
+    op_str = op_name
+    if param_parts:
+        op_str += "(" + ", ".join(param_parts) + ")"
+
+    left = ", ".join(str(s) for s in rule.source)
+    right = ", ".join(str(s) for s in rule.target)
+    base = f"{op_str} [{left}] -> [{right}]"
+    if rule.nature:
+        base += f" [{rule.nature.value}]"
+    return base
 
 
 def generate_fallback_rules(inp: "Grid", out: "Grid") -> list[SymbolicRule]:

--- a/arc_solver/tests/test_rule_language.py
+++ b/arc_solver/tests/test_rule_language.py
@@ -38,3 +38,25 @@ def test_parse_new_transforms():
     r2 = parse_rule("SHAPE_ABSTRACT [SHAPE=A] -> [SHAPE=A]")
     assert r1.transformation.ttype is TransformationType.ROTATE90
     assert r2.transformation.ttype is TransformationType.SHAPE_ABSTRACT
+
+
+def _roundtrip(dsl: str) -> None:
+    obj = parse_rule(dsl)
+    out = rule_to_dsl(obj)
+    obj2 = parse_rule(out)
+    assert rule_to_dsl(obj2) == out
+    assert obj2.transformation.params == obj.transformation.params
+    assert obj2.meta == obj.meta
+
+
+def test_extended_operator_roundtrip():
+    cases = [
+        "mirror_tile(axis=horizontal, repeats=2) [REGION=All] -> [REGION=All]",
+        "pattern_fill(mapping={1:2}) [REGION=All] -> [REGION=All]",
+        "rotate_about_point(pivot=(1,2), angle=90) [REGION=All] -> [REGION=All]",
+        "zone_remap(mapping={1:3}) [REGION=All] -> [REGION=All]",
+        "dilate_zone(zone_id=1) [ZONE=1] -> [ZONE=1]",
+        "erode_zone(zone_id=2) [ZONE=2] -> [ZONE=2]",
+    ]
+    for dsl in cases:
+        _roundtrip(dsl)


### PR DESCRIPTION
## Summary
- enhance `parse_rule` to understand parameterized operators like `mirror_tile`, `rotate_about_point`, etc.
- add serialization logic in `rule_to_dsl` for new operators
- record pivot information in composite rule proxies
- provide DSL round‑trip tests for new operator grammar

## Testing
- `pip install -e .`
- `pytest -q arc_solver/tests/test_rule_language.py`
- `pytest -q` *(fails: 65 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6871f6ce2bd48322a7efcdb306e538ba