### PR TITLE
Add heuristics for new functional operators

### DIFF
--- a/arc_solver/src/abstractions/rule_generator.py
+++ b/arc_solver/src/abstractions/rule_generator.py
@@ -117,7 +117,12 @@ def remove_duplicate_rules(
         return _sig(getattr(r, "meta", {}))
 
     for rule in rules:
-        sig = normalize_rule_dsl(rule_to_dsl(rule)) + _meta_signature(rule)
+        if isinstance(rule, CompositeRule):
+            proxy = rule.as_symbolic_proxy()
+            sig_dsl = rule_to_dsl(proxy)
+        else:
+            sig_dsl = rule_to_dsl(rule)
+        sig = normalize_rule_dsl(sig_dsl) + _meta_signature(rule)
         h = hash(sig)
         if h not in seen_hashes:
             deduped.append(rule)


### PR DESCRIPTION
## Summary
- extend the abstractor with rule generators for mirror_tile, pattern_fill, rotate_about_point, dilate_zone and erode_zone
- record debug information when these heuristics fire
- expose helper functions in `__all__`
- handle composite rule DSL generation when deduplicating rules

## Testing
- `pytest arc_solver/tests/test_symbolic_ops.py tests/test_symbolic_operators.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871fa0c199c832281f596ba73052ae9