### PR TITLE
Improve functional validation

### DIFF
--- a/arc_solver/src/executor/simulator.py
+++ b/arc_solver/src/executor/simulator.py
@@ -112,7 +112,7 @@ def simulate_composite_safe(
                 failed_step_index=idx,
                 reason="grid_expansion_failure",
             )
-            raise ValidationError(
+            raise UnsafeTransformationError(
                 f"grid would expand to {forecast}, exceeding {MAX_GRID_DIM}x{MAX_GRID_DIM}"
             )
         if uncertainty_grid is not None and forecast != out.shape():

--- a/arc_solver/tests/test_validator.py
+++ b/arc_solver/tests/test_validator.py
@@ -80,3 +80,27 @@ def test_training_color_override_accept():
         training_colors={2},
         lineage_tracker=tracker,
     )
+
+
+def test_training_color_mismatch_allowed_by_zone_remap():
+    grid = Grid([[1]])
+    rule = SymbolicRule(
+        transformation=Transformation(TransformationType.FUNCTIONAL, params={"op": "zone_remap"}),
+        source=[Symbol(SymbolType.REGION, "All")],
+        target=[Symbol(SymbolType.REGION, "All")],
+        meta={"mapping": {0: 2}},
+    )
+    comp = CompositeRule([rule])
+    assert validate_color_dependencies([comp], grid, training_colors={1})
+
+
+def test_training_color_mismatch_without_transform_fails():
+    grid = Grid([[1]])
+    rule = SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "2")],
+    )
+    comp = CompositeRule([rule])
+    assert not validate_color_dependencies([comp], grid, training_colors={1})
+


### PR DESCRIPTION
## Summary
- update functional safety checks and raise `UnsafeTransformationError` on grid overflow
- allow explicit colour operations (zone_remap/pattern_fill) when validating colour dependencies
- test colour validation with zone_remap

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872070e656883228dafaca0be799f50