### PR TITLE
Complete DSL operator registry

### DIFF
--- a/arc_solver/src/symbolic/mirror_tile.py
+++ b/arc_solver/src/symbolic/mirror_tile.py
@@ -1,0 +1,2 @@
+from .operators import mirror_tile
+__all__ = ["mirror_tile"]

--- a/arc_solver/tests/test_rule_language.py
+++ b/arc_solver/tests/test_rule_language.py
@@ -1,11 +1,21 @@
+import importlib.util
+from pathlib import Path
 import pytest
 
-from arc_solver.src.symbolic.rule_language import (
-    parse_rule,
-    rule_to_dsl,
-    validate_dsl_program,
-    clean_dsl_string,
+ROOT = Path(__file__).resolve().parents[2]
+module_name = "arc_solver.src.symbolic.rule_language"
+spec = importlib.util.spec_from_file_location(
+    module_name,
+    ROOT / "arc_solver" / "src" / "symbolic" / "rule_language.py",
 )
+rule_language = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(rule_language)  # type: ignore
+
+parse_rule = rule_language.parse_rule
+rule_to_dsl = rule_language.rule_to_dsl
+validate_dsl_program = rule_language.validate_dsl_program
+clean_dsl_string = rule_language.clean_dsl_string
+get_extended_operators = rule_language.get_extended_operators
 from arc_solver.src.symbolic.vocabulary import SymbolicRule, TransformationType
 
 
@@ -47,6 +57,19 @@ def _roundtrip(dsl: str) -> None:
     assert rule_to_dsl(obj2) == out
     assert obj2.transformation.params == obj.transformation.params
     assert obj2.meta == obj.meta
+
+
+def test_operator_registry_keys():
+    ops = get_extended_operators()
+    expected = {
+        "mirror_tile",
+        "pattern_fill",
+        "rotate_about_point",
+        "zone_remap",
+        "dilate_zone",
+        "erode_zone",
+    }
+    assert expected <= set(ops)
 
 
 def test_extended_operator_roundtrip():

--- a/docs/generated_dsl_operators.md
+++ b/docs/generated_dsl_operators.md
@@ -155,3 +155,99 @@
 ```python
 # Example coming soon
 ```
+
+## dilate_zone
+
+**DSL Keyword:** `dilate_zone`
+
+**Transformation Type:** `FUNCTIONAL`
+
+**Parameters:** zone_id
+
+**Description:** Dilate the pixels of ``zone_id`` by one cell inside ``zone_overlay``.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## erode_zone
+
+**DSL Keyword:** `erode_zone`
+
+**Transformation Type:** `FUNCTIONAL`
+
+**Parameters:** zone_id
+
+**Description:** Erode ``zone_id`` by removing boundary pixels within ``zone_overlay``.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## mirror_tile
+
+**DSL Keyword:** `mirror_tile`
+
+**Transformation Type:** `FUNCTIONAL`
+
+**Parameters:** axis, repeats
+
+**Description:** Return grid tiled ``count`` times while mirroring every other tile.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## pattern_fill
+
+**DSL Keyword:** `pattern_fill`
+
+**Transformation Type:** `FUNCTIONAL`
+
+**Parameters:** mapping
+
+**Description:** Return ``grid`` with a pattern copied from ``source_zone_id`` to ``target_zone_id``.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## rotate_about_point
+
+**DSL Keyword:** `rotate_about_point`
+
+**Transformation Type:** `ROTATE`
+
+**Parameters:** pivot, angle
+
+**Description:** Return ``grid`` rotated ``angle`` degrees about ``center``.
+
+**Example:**
+
+```python
+# Example coming soon
+```
+
+## zone_remap
+
+**DSL Keyword:** `zone_remap`
+
+**Transformation Type:** `FUNCTIONAL`
+
+**Parameters:** mapping
+
+**Description:** Return a new grid with zones recoloured via ``zone_to_color``.
+
+**Example:**
+
+```python
+# Example coming soon
+```


### PR DESCRIPTION
## Summary
- implement `OperatorSpec` and registry in DSL parser
- refactor parsing and serialisation to use the registry
- add tests for registry presence and round-trip of extended operators
- generate operator documentation via updated script

## Testing
- `PYTHONPATH=. pytest arc_solver/tests/test_rule_language.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6872213732c88322b95bc903de79daf4