### PR TITLE
Improve composite fallback logic

### DIFF
--- a/arc_solver/src/abstractions/abstractor.py
+++ b/arc_solver/src/abstractions/abstractor.py
@@ -1096,6 +1096,21 @@ def abstract(
             if score_rule(input_grid, output_grid, r) > 0.5
         ]
         valid_rules.extend(fallback_rules)
+
+    if (
+        ENABLE_FALLBACK_COMPOSITES
+        and valid_rules
+        and max(score_rule(input_grid, output_grid, r) for r in valid_rules)
+        < RELIABILITY_THRESHOLD
+    ):
+        from arc_solver.src.abstractions.rule_generator import fallback_composite_rules
+
+        comps = fallback_composite_rules(
+            valid_rules, input_grid, output_grid, score_threshold=RELIABILITY_THRESHOLD
+        )
+        fallback_rules.extend(comps)
+        valid_rules.extend(comps)
+
     if trace_entry is not None:
         trace_entry["fallback_rules_used"] = len(fallback_rules)
 

--- a/arc_solver/src/executor/scoring.py
+++ b/arc_solver/src/executor/scoring.py
@@ -162,6 +162,16 @@ def _op_cost(rule: SymbolicRule | CompositeRule) -> float:
     return float(cost)
 
 
+def rule_cost(rule: SymbolicRule | CompositeRule) -> float:
+    """Return weighted complexity cost for ``rule``."""
+
+    if isinstance(rule, CompositeRule):
+        cost = sum(_op_cost(step) for step in rule.steps)
+        cost += 0.5 * len(rule.steps)
+        return float(cost)
+    return float(_op_cost(rule))
+
+
 def _extract_zones(rule: SymbolicRule | CompositeRule) -> List[str]:
     """Return sorted unique zones referenced by ``rule``."""
 
@@ -330,4 +340,10 @@ def score_rule(
     return final
 
 
-__all__ = ["score_rule", "preferred_rule_types", "STRATEGY_REGISTRY", "op_penalty"]
+__all__ = [
+    "score_rule",
+    "preferred_rule_types",
+    "STRATEGY_REGISTRY",
+    "op_penalty",
+    "rule_cost",
+]

--- a/tests/test_composite_fallback.py
+++ b/tests/test_composite_fallback.py
@@ -1,0 +1,43 @@
+import pytest
+from arc_solver.src.core.grid import Grid
+from arc_solver.src.symbolic.vocabulary import SymbolicRule, Transformation, TransformationType, Symbol, SymbolType
+from arc_solver.src.symbolic.rule_language import CompositeRule
+from arc_solver.src.abstractions.rule_generator import fallback_composite_rules
+from arc_solver.src.executor.scoring import score_rule
+
+
+def _replace(src, tgt, **meta):
+    return SymbolicRule(
+        transformation=Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, str(src))],
+        target=[Symbol(SymbolType.COLOR, str(tgt))],
+        meta=meta,
+    )
+
+
+def test_fallback_generates_and_deduplicates():
+    inp = Grid([[1]])
+    out = Grid([[3]])
+    r1 = _replace(1, 2, source="A")
+    r1_dup = _replace(1, 2, source="B")
+    r2 = _replace(2, 3)
+
+    chains = fallback_composite_rules([r1, r1_dup, r2], inp, out, score_threshold=0.9)
+    assert chains, "expected fallback chain generation"
+    assert len(chains) < 30
+    assert any(isinstance(c, CompositeRule) and c.simulate(inp) == out for c in chains)
+    scores = [score_rule(inp, out, c) for c in chains]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_fallback_filters_invalid():
+    inp = Grid([[1]])
+    out = Grid([[2] * 64])
+    invalid = SymbolicRule(
+        transformation=Transformation(TransformationType.REPEAT, params={"kx": "65", "ky": "1"}),
+        source=[Symbol(SymbolType.REGION, "All")],
+        target=[Symbol(SymbolType.REGION, "All")],
+    )
+    r = _replace(1, 2)
+    chains = fallback_composite_rules([invalid, r], inp, out, score_threshold=0.9)
+    assert all(all(step.transformation.ttype != TransformationType.REPEAT or step.transformation.params.get("kx") != "65" for step in c.steps) for c in chains)


### PR DESCRIPTION
## Summary
- enhance rule scoring with `rule_cost` penalty for long chains
- add `fallback_composite_rules` to build multi-step chains when single rules fail
- trigger composite fallback from `abstract` when all base scores are low
- unit test for composite fallback generation and filtering

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest tests/test_composite_fallback.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68723144615c8322bd2071d865c6ed21