### PR TITLE
Implement rule generalization merging

### DIFF
--- a/arc_solver/src/abstractions/abstractor.py
+++ b/arc_solver/src/abstractions/abstractor.py
@@ -1047,6 +1047,14 @@ def abstract(
                 split.append(r)
         rules = split
 
+        # Consolidate near-identical rules before scoring
+        try:
+            from arc_solver.src.utils.rule_utils import generalize_rules as _gen_rules
+
+            rules = _gen_rules(rules)
+        except Exception:
+            pass
+
         # ------------------------------------------------------------------
         # Prioritize rules using scoring and strategy registry
         # ------------------------------------------------------------------

--- a/arc_solver/src/executor/scoring.py
+++ b/arc_solver/src/executor/scoring.py
@@ -272,7 +272,14 @@ def score_rule(
     else:
         bonus = 0.0
 
-    final = base - penalty + bonus
+    # Small diversity penalty when metadata encodes many variants
+    diversity_penalty = 0.0
+    meta = getattr(rule, "meta", {})
+    if any(isinstance(v, list) for v in meta.values()):
+        width = sum(len(v) if isinstance(v, list) else 1 for v in meta.values())
+        diversity_penalty = 0.02 * max(0, width - len(meta) - 2)
+
+    final = base - penalty - diversity_penalty + bonus
 
     # === Zone-Aware Scoring Hooks  ===
     if ENABLE_ZONE_SCORING:

--- a/arc_solver/src/utils/__init__.py
+++ b/arc_solver/src/utils/__init__.py
@@ -6,6 +6,7 @@ from .patterns import (
     detect_repeating_blocks,
     detect_replace_map,
 )
+from .rule_utils import generalize_rules
 
 __all__ = [
     "extract_task_signature",
@@ -15,4 +16,5 @@ __all__ = [
     "detect_mirrored_regions",
     "detect_repeating_blocks",
     "detect_replace_map",
+    "generalize_rules",
 ]

--- a/arc_solver/src/utils/rule_utils.py
+++ b/arc_solver/src/utils/rule_utils.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import List, Dict
+import json
+from pathlib import Path
+
+from arc_solver.src.symbolic.vocabulary import SymbolicRule
+from arc_solver.src.symbolic.rule_language import rule_to_dsl
+
+
+def generalize_rules(rules: List[SymbolicRule]) -> List[SymbolicRule]:
+    """Return list of rules merged by identical DSL."""
+
+    groups: Dict[str, List[SymbolicRule]] = {}
+    for r in rules:
+        dsl = getattr(r, "dsl_str", None) or rule_to_dsl(r)
+        r.dsl_str = dsl
+        groups.setdefault(dsl, []).append(r)
+
+    generalized: List[SymbolicRule] = []
+    trace = {"original_count": len(rules), "groups": []}
+
+    for dsl, bucket in groups.items():
+        merged = bucket[0]
+        for other in bucket[1:]:
+            g = merged.generalize_with(other)
+            if g:
+                merged = g
+            else:
+                generalized.append(merged)
+                merged = other
+        generalized.append(merged)
+        trace["groups"].append({"dsl": dsl, "count": len(bucket)})
+
+    trace["final_count"] = len(generalized)
+    try:
+        path = Path("logs/generalization_trace.jsonl")
+        path.parent.mkdir(exist_ok=True)
+        path.open("a", encoding="utf-8").write(json.dumps(trace) + "\n")
+    except Exception:
+        pass
+
+    return generalized
+
+
+__all__ = ["generalize_rules"]

--- a/tests/test_rule_utils_generalization.py
+++ b/tests/test_rule_utils_generalization.py
@@ -1,0 +1,28 @@
+import pytest
+from arc_solver.src.symbolic import Symbol, SymbolType, SymbolicRule, Transformation, TransformationType
+from arc_solver.src.utils.rule_utils import generalize_rules
+
+
+def _repl(zone: str) -> SymbolicRule:
+    return SymbolicRule(
+        Transformation(TransformationType.REPLACE),
+        source=[Symbol(SymbolType.COLOR, "1")],
+        target=[Symbol(SymbolType.COLOR, "2")],
+        meta={"zone": zone},
+    )
+
+
+def test_generalize_with_merges_meta():
+    r1 = _repl("A")
+    r2 = _repl("B")
+    merged = r1.generalize_with(r2)
+    assert merged is not None
+    assert merged.meta["zone"] == ["A", "B"]
+
+
+def test_generalize_rules_groups_by_dsl(tmp_path):
+    r1 = _repl("A")
+    r2 = _repl("B")
+    out = generalize_rules([r1, r2])
+    assert len(out) == 1
+    assert out[0].meta["zone"] == ["A", "B"]


### PR DESCRIPTION
## Summary
- add `generalize_with` and `dsl` helper on `SymbolicRule`
- implement `generalize_rules` utility with logging
- apply generalization in `abstractor` prior to scoring
- penalise over-generalised metadata in scoring
- add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687234b622a88322ab682849167c9368