### PR TITLE
Update DSL operator registry and docs

### DIFF
--- a/arc_solver/src/symbolic/vocabulary.py
+++ b/arc_solver/src/symbolic/vocabulary.py
@@ -381,8 +381,8 @@ EXTENDED_OPERATORS: Dict[str, Dict[str, Any]] = {
 }
 
 
-def get_extended_operators() -> Dict[str, Dict[str, Any]]:
-    """Return registry of extended symbolic operators."""
+def get_extended_operators() -> Dict[str, Callable[..., SymbolicRule]]:
+    """Return mapping of operator names to rule factory functions."""
 
-    return EXTENDED_OPERATORS
+    return {name: spec["rule"] for name, spec in EXTENDED_OPERATORS.items()}
 

--- a/docs/dsl_autogen_doc.py
+++ b/docs/dsl_autogen_doc.py
@@ -9,23 +9,11 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
 
-import importlib.util
-
-vocab_spec = importlib.util.spec_from_file_location(
-    "arc_solver.src.symbolic.vocabulary",
-    Path(ROOT / "arc_solver" / "src" / "symbolic" / "vocabulary.py").as_posix(),
-)
-vocabulary = importlib.util.module_from_spec(vocab_spec)
-vocab_spec.loader.exec_module(vocabulary)  # type: ignore
-
-spec = importlib.util.spec_from_file_location(
-    "arc_solver.src.symbolic.rule_language",
-    Path(ROOT / "arc_solver" / "src" / "symbolic" / "rule_language.py").as_posix(),
-)
-rule_language = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(rule_language)  # type: ignore
+vocabulary = importlib.import_module("arc_solver.src.symbolic.vocabulary")
+rule_language = importlib.import_module("arc_solver.src.symbolic.rule_language")
 get_extended_operators = rule_language.get_extended_operators
 OperatorSpec = rule_language.OperatorSpec
+vocab_get_ops = vocabulary.get_extended_operators
 
 
 def _discover_symbolic_modules():
@@ -71,6 +59,16 @@ def generate_dsl_docs(output_path: str = "docs/generated_dsl_operators.md") -> N
         lines.append("```python\n# Example coming soon\n```\n")
 
     ext = get_extended_operators()
+    vocab_ops = vocab_get_ops()
+    sample_args = {
+        "mirror_tile": ("horizontal", 2),
+        "pattern_fill": (None, None),
+        "draw_line": ((0, 0), (1, 1), 1),
+        "dilate_zone": (1,),
+        "erode_zone": (1,),
+        "rotate_about_point": ((1, 1), 90),
+        "zone_remap": (None, {1: 2}),
+    }
     for name, spec in sorted(ext.items()):
         syntax, desc = _find_operator_info(name, modules)
         if syntax is None:
@@ -81,9 +79,23 @@ def generate_dsl_docs(output_path: str = "docs/generated_dsl_operators.md") -> N
         lines.append(f"**DSL Keyword:** `{name}`\n")
         lines.append(f"**Transformation Type:** `{spec.ttype.value}`\n")
         lines.append(f"**Parameters:** {', '.join(spec.params)}\n")
+        lines.append("**DSL Version:** v1\n")
         lines.append(f"**Description:** {desc}\n")
+        example = "# Example coming soon"
+        impl_path = None
+        rule_fn = vocab_ops.get(name)
+        if rule_fn:
+            args = sample_args.get(name, ())
+            try:
+                rule = rule_fn(*args)
+                example = rule_language.rule_to_dsl(rule)
+                impl_path = Path(inspect.getsourcefile(rule_fn)).relative_to(ROOT)
+            except Exception:
+                pass
         lines.append("**Example:**\n")
-        lines.append("```python\n# Example coming soon\n```\n")
+        lines.append(f"```python\n{example}\n```\n")
+        if impl_path:
+            lines.append(f"**Implementation:** `{impl_path}`\n")
 
     Path(output_path).parent.mkdir(parents=True, exist_ok=True)
     Path(output_path).write_text("\n".join(lines))

--- a/docs/generated_dsl_operators.md
+++ b/docs/generated_dsl_operators.md
@@ -164,13 +164,37 @@
 
 **Parameters:** zone_id
 
+**DSL Version:** v1
+
 **Description:** Dilate the pixels of ``zone_id`` by one cell inside ``zone_overlay``.
 
 **Example:**
 
 ```python
-# Example coming soon
+dilate_zone(zone_id=1) [ZONE=1] -> [ZONE=1] [SPATIAL]
 ```
+
+**Implementation:** `arc_solver/src/symbolic/vocabulary.py`
+
+## draw_line
+
+**DSL Keyword:** `draw_line`
+
+**Transformation Type:** `FUNCTIONAL`
+
+**Parameters:** p1, p2, color
+
+**DSL Version:** v1
+
+**Description:** Draw a 4-connected line on ``grid`` between ``point1`` and ``point2``.
+
+**Example:**
+
+```python
+draw_line(p1=(0, 0), p2=(1, 1), color=1) [REGION=All] -> [REGION=All] [SPATIAL]
+```
+
+**Implementation:** `arc_solver/src/symbolic/vocabulary.py`
 
 ## erode_zone
 
@@ -180,13 +204,17 @@
 
 **Parameters:** zone_id
 
+**DSL Version:** v1
+
 **Description:** Erode ``zone_id`` by removing boundary pixels within ``zone_overlay``.
 
 **Example:**
 
 ```python
-# Example coming soon
+erode_zone(zone_id=1) [ZONE=1] -> [ZONE=1] [SPATIAL]
 ```
+
+**Implementation:** `arc_solver/src/symbolic/vocabulary.py`
 
 ## mirror_tile
 
@@ -196,13 +224,17 @@
 
 **Parameters:** axis, repeats
 
+**DSL Version:** v1
+
 **Description:** Return grid tiled ``count`` times while mirroring every other tile.
 
 **Example:**
 
 ```python
-# Example coming soon
+mirror_tile(axis=horizontal, repeats=2) [REGION=All] -> [REGION=All] [SPATIAL]
 ```
+
+**Implementation:** `arc_solver/src/symbolic/vocabulary.py`
 
 ## pattern_fill
 
@@ -212,13 +244,17 @@
 
 **Parameters:** mapping
 
+**DSL Version:** v1
+
 **Description:** Return ``grid`` with a pattern copied from ``source_zone_id`` to ``target_zone_id``.
 
 **Example:**
 
 ```python
-# Example coming soon
+pattern_fill [REGION=All] -> [REGION=All] [SPATIAL]
 ```
+
+**Implementation:** `arc_solver/src/symbolic/vocabulary.py`
 
 ## rotate_about_point
 
@@ -228,13 +264,17 @@
 
 **Parameters:** pivot, angle
 
+**DSL Version:** v1
+
 **Description:** Return ``grid`` rotated ``angle`` degrees about ``center``.
 
 **Example:**
 
 ```python
-# Example coming soon
+rotate_about_point(pivot=(1,1), angle=90) [REGION=All] -> [REGION=All] [SPATIAL]
 ```
+
+**Implementation:** `arc_solver/src/symbolic/vocabulary.py`
 
 ## zone_remap
 
@@ -244,10 +284,14 @@
 
 **Parameters:** mapping
 
+**DSL Version:** v1
+
 **Description:** Return a new grid with zones recoloured via ``zone_to_color``.
 
 **Example:**
 
 ```python
-# Example coming soon
+zone_remap(mapping={1: 2}) [REGION=All] -> [REGION=All] [SPATIAL]
 ```
+
+**Implementation:** `arc_solver/src/symbolic/vocabulary.py`

--- a/tests/test_dsl_roundtrip.py
+++ b/tests/test_dsl_roundtrip.py
@@ -1,0 +1,23 @@
+from arc_solver.src.symbolic.vocabulary import get_extended_operators
+from arc_solver.src.symbolic.rule_language import parse_rule, rule_to_dsl
+
+SAMPLES = {
+    "mirror_tile": ("horizontal", 2),
+    "pattern_fill": (None, None),
+    "draw_line": ((0, 0), (1, 1), 1),
+    "dilate_zone": (1,),
+    "erode_zone": (1,),
+    "rotate_about_point": ((1, 1), 90),
+    "zone_remap": (None, {1: 2}),
+}
+
+
+def test_registry_roundtrip():
+    ops = get_extended_operators()
+    for name, factory in ops.items():
+        args = SAMPLES.get(name, ())
+        rule = factory(*args)
+        rule.meta = {}
+        dsl = rule_to_dsl(rule)
+        parsed = parse_rule(dsl)
+        assert parsed == rule


### PR DESCRIPTION
## Summary
- extend DSL parsing to handle nested parameters and trailing nature tokens
- add draw_line operator spec and update registry helpers
- document functional operators with examples and implementation links
- expose simple factory registry via `vocabulary.get_extended_operators`
- test DSL round trip across all operators

## Testing
- `PYTHONPATH=. pytest tests/test_dsl_roundtrip.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68724b7a94548322ac590221104328e3